### PR TITLE
Rename hub base class to multi-device factory for clarity

### DIFF
--- a/OpenEphys.Onix/ConfigureBreakoutBoard.cs
+++ b/OpenEphys.Onix/ConfigureBreakoutBoard.cs
@@ -7,33 +7,33 @@ namespace OpenEphys.Onix
     /// A class that configures an ONIX breakout board.
     /// </summary>
     [Description("Configures an ONIX breakout board.")]
-    public class ConfigureBreakoutBoard : HubDeviceFactory
+    public class ConfigureBreakoutBoard : MultiDeviceFactory
     {
         /// <summary>
         /// Gets or sets the heartbeat configuration.
         /// </summary>
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the heartbeat device in the ONIX breakout board.")]
         public ConfigureHeartbeat Heartbeat { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the breakout board's analog IO configuration.
         /// </summary>
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the analog IO device in the ONIX breakout board.")]
         public ConfigureBreakoutAnalogIO AnalogIO { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the breakout board's digital IO configuration.
         /// </summary>
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the digital IO device in the ONIX breakout board.")]
         public ConfigureBreakoutDigitalIO DigitalIO { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the hardware memory monitor configuration.
         /// </summary>
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the memory monitor device in the ONIX breakout board.")]
         public ConfigureMemoryMonitor MemoryMonitor { get; set; } = new();
 

--- a/OpenEphys.Onix/ConfigureHarpSyncInput.cs
+++ b/OpenEphys.Onix/ConfigureHarpSyncInput.cs
@@ -7,20 +7,24 @@ namespace OpenEphys.Onix
     /// A class for configuring the ONIX breakout board Harp sync input device.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Harp is a standard for asynchronous real-time data acquisition and experimental
     /// control in neuroscience. It includes a clock synchronization protocol which allows
     /// Harp devices to be connected to a shared clock line and continuously self-synchronize
     /// their clocks to a precision of tens of microseconds. This means that all experimental
     /// events are timestamped on the same clock and no post-hoc alignment of timing is necessary.
-    /// 
+    /// </para>
+    /// <para>
     /// The Harp clock signal is transmitted over a serial line every second.
     /// Every time the Harp sync input device in the ONIX breakout board detects a full Harp
     /// synchronization packet, a new data frame is emitted pairing the current value of the
     /// Harp clock with the local ONIX acquisition clock.
-    /// 
+    /// </para>
+    /// <para>
     /// Logging the sequence of all Harp synchronization packets can greatly facilitate post-hoc
     /// analysis and interpretation of timing signals. For more information see
     /// <see href="https://harp-tech.org/"/>.
+    /// </para>
     /// </remarks>
     [Description("Configures a ONIX breakout board Harp sync input device.")]
     public class ConfigureHarpSyncInput : SingleDeviceFactory

--- a/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -8,7 +8,7 @@ namespace OpenEphys.Onix
     /// A class that configures an ONIX headstage-64 in the specified port.
     /// </summary>
     [Description("Configures an ONIX headstage-64 in the specified port.")]
-    public class ConfigureHeadstage64 : HubDeviceFactory
+    public class ConfigureHeadstage64 : MultiDeviceFactory
     {
         PortName port;
         readonly ConfigureHeadstage64LinkController LinkController = new();
@@ -42,7 +42,7 @@ namespace OpenEphys.Onix
         /// Gets or sets the Rhd2164 configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the Rhd2164 device in the headstage-64.")]
         public ConfigureRhd2164 Rhd2164 { get; set; } = new();
 
@@ -50,7 +50,7 @@ namespace OpenEphys.Onix
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the Bno055 device in the headstage-64.")]
         public ConfigureBno055 Bno055 { get; set; } = new();
 
@@ -58,7 +58,7 @@ namespace OpenEphys.Onix
         /// Gets or sets the SteamVR V1 basestation 3D tracking array configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the TS4231 device in the headstage-64.")]
         public ConfigureTS4231V1 TS4231 { get; set; } = new() { Enable = false };
 
@@ -66,7 +66,7 @@ namespace OpenEphys.Onix
         /// Gets or sets onboard electrical stimulator configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the ElectricalStimulator device in the headstage-64.")]
         public ConfigureHeadstage64ElectricalStimulator ElectricalStimulator { get; set; } = new();
 
@@ -74,7 +74,7 @@ namespace OpenEphys.Onix
         /// Gets or sets onboard optical stimulator configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the OpticalStimulator device in the headstage-64.")]
         public ConfigureHeadstage64OpticalStimulator OpticalStimulator { get; set; } = new();
 

--- a/OpenEphys.Onix/ConfigureNeuropixelsV1eHeadstage.cs
+++ b/OpenEphys.Onix/ConfigureNeuropixelsV1eHeadstage.cs
@@ -8,7 +8,7 @@ namespace OpenEphys.Onix
     /// A class that configures a NeuropixelsV1e headstage.
     /// </summary>
     [Description("Configures a NeuropixelsV1e headstage.")]
-    public class ConfigureNeuropixelsV1eHeadstage : HubDeviceFactory
+    public class ConfigureNeuropixelsV1eHeadstage : MultiDeviceFactory
     {
         PortName port;
         readonly ConfigureNeuropixelsV1eLinkController LinkController = new();
@@ -26,7 +26,7 @@ namespace OpenEphys.Onix
         /// Gets or sets the NeuropixelsV1e configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the NeuropixelsV1e device.")]
         public ConfigureNeuropixelsV1e NeuropixelsV1e { get; set; } = new();
 
@@ -34,7 +34,7 @@ namespace OpenEphys.Onix
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigureNeuropixelsV1eBno055 Bno055 { get; set; } = new();
 

--- a/OpenEphys.Onix/ConfigureNeuropixelsV2eBetaHeadstage.cs
+++ b/OpenEphys.Onix/ConfigureNeuropixelsV2eBetaHeadstage.cs
@@ -7,7 +7,7 @@ namespace OpenEphys.Onix
     /// A class that configures a NeuropixelsV2eBeta headstage.
     /// </summary>
     [Description("Configures a NeuropixelsV2eBeta headstage.")]
-    public class ConfigureNeuropixelsV2eBetaHeadstage : HubDeviceFactory
+    public class ConfigureNeuropixelsV2eBetaHeadstage : MultiDeviceFactory
     {
         PortName port;
         readonly ConfigureNeuropixelsV2eLinkController LinkController = new();
@@ -25,7 +25,7 @@ namespace OpenEphys.Onix
         /// Gets or sets the NeuropixelsV2eBeta configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the NeuropixelsV2eBeta device.")]
         public ConfigureNeuropixelsV2eBeta NeuropixelsV2eBeta { get; set; } = new();
 
@@ -33,7 +33,7 @@ namespace OpenEphys.Onix
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigureNeuropixelsV2eBno055 Bno055 { get; set; } = new();
 

--- a/OpenEphys.Onix/ConfigureNeuropixelsV2eHeadstage.cs
+++ b/OpenEphys.Onix/ConfigureNeuropixelsV2eHeadstage.cs
@@ -7,7 +7,7 @@ namespace OpenEphys.Onix
     /// A class that configures a NeuropixelsV2e headstage.
     /// </summary>
     [Description("configures a NeuropixelsV2e headstage.")]
-    public class ConfigureNeuropixelsV2eHeadstage : HubDeviceFactory
+    public class ConfigureNeuropixelsV2eHeadstage : MultiDeviceFactory
     {
         PortName port;
         readonly ConfigureNeuropixelsV2eLinkController LinkController = new();
@@ -25,7 +25,7 @@ namespace OpenEphys.Onix
         /// Gets or sets the NeuropixelsV2e configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the NeuropixelsV2e device.")]
         public ConfigureNeuropixelsV2e NeuropixelsV2e { get; set; } = new();
 
@@ -33,7 +33,7 @@ namespace OpenEphys.Onix
         /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
-        [TypeConverter(typeof(HubDeviceConverter))]
+        [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigureNeuropixelsV2eBno055 Bno055 { get; set; } = new();
 

--- a/OpenEphys.Onix/MultiDeviceFactory.cs
+++ b/OpenEphys.Onix/MultiDeviceFactory.cs
@@ -9,21 +9,24 @@ namespace OpenEphys.Onix
     /// registering all devices in an ONI device aggregate in the context device table.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// ONI devices are often grouped into multi-device aggregates connected to hubs or
     /// headstages. These aggregates provide access to multiple devices through hub-specific
     /// addresses and usually require a specific sequence of configuration steps to determine
     /// operational port voltages and other link-specific settings.
-    /// 
+    /// </para>
+    /// <para>
     /// These multi-device aggregates are the most common starting point for configuration
-    /// of an ONI system, and the <see cref="HubDeviceFactory"/> provides a modular abstraction
+    /// of an ONI system, and the <see cref="MultiDeviceFactory"/> provides a modular abstraction
     /// for flexible assembly and sequencing of multiple such aggregates.
+    /// </para>
     /// </remarks>
-    public abstract class HubDeviceFactory : DeviceFactory, INamedElement
+    public abstract class MultiDeviceFactory : DeviceFactory, INamedElement
     {
         const string BaseTypePrefix = "Configure";
         string _name;
 
-        internal HubDeviceFactory()
+        internal MultiDeviceFactory()
         {
             var baseName = GetType().Name;
             var prefixIndex = baseName.IndexOf(BaseTypePrefix);

--- a/OpenEphys.Onix/SingleDeviceFactoryConverter.cs
+++ b/OpenEphys.Onix/SingleDeviceFactoryConverter.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace OpenEphys.Onix
 {
-    internal class HubDeviceConverter : ExpandableObjectConverter
+    internal class SingleDeviceFactoryConverter : ExpandableObjectConverter
     {
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {


### PR DESCRIPTION
The `HubDeviceFactory` has evolved to represent not only proper ONI hubs, but virtually any composite configuration of a multi-device aggregate. This includes hardware headstages but also potentially fully virtual devices.

To reflect this flexibility in intended use we are renaming the base class to `MultiDeviceFactory`. Other associated classes and docs have also been renamed for naming consistency.