### PR TITLE
Update bootstrapper version

### DIFF
--- a/.bonsai/Bonsai.config
+++ b/.bonsai/Bonsai.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Bonsai" version="2.8.1" />
-    <Package id="Bonsai.Core" version="2.8.1" />
-    <Package id="Bonsai.Design" version="2.8.0" />
+    <Package id="Bonsai" version="2.8.5" />
+    <Package id="Bonsai.Core" version="2.8.5" />
+    <Package id="Bonsai.Design" version="2.8.5" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
-    <Package id="Bonsai.Dsp" version="2.8.0" />
+    <Package id="Bonsai.Dsp" version="2.8.1" />
     <Package id="Bonsai.Dsp.Design" version="2.8.0" />
-    <Package id="Bonsai.Editor" version="2.8.0" />
+    <Package id="Bonsai.Editor" version="2.8.5" />
     <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.System" version="2.8.0" />
+    <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.System.Design" version="2.8.0" />
-    <Package id="Bonsai.Vision" version="2.8.0" />
-    <Package id="Bonsai.Vision.Design" version="2.8.0" />
+    <Package id="Bonsai.Vision" version="2.8.1" />
+    <Package id="Bonsai.Vision.Design" version="2.8.1" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
     <Package id="Markdig" version="0.18.1" />
     <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
@@ -25,7 +25,12 @@
     <Package id="Rx-Linq" version="2.2.5" />
     <Package id="Rx-PlatformServices" version="2.2.5" />
     <Package id="SvgNet" version="3.3.3" />
+    <Package id="System.Buffers" version="4.5.1" />
     <Package id="System.Linq.Dynamic" version="1.0.7" />
+    <Package id="System.Memory" version="4.5.5" />
+    <Package id="System.Numerics.Vectors" version="4.5.0" />
+    <Package id="System.Resources.Extensions" version="8.0.0" />
+    <Package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" />
     <Package id="YamlDotNet" version="13.1.1" />
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
@@ -45,19 +50,19 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.1\lib\net48\Bonsai.exe" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.5\lib\net48\Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.5\lib\net462\Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.5\lib\net462\Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.1\lib\net462\Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.Design.2.8.0\lib\net462\Bonsai.Dsp.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.0\lib\net472\Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.5\lib\net472\Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.2.8.0\lib\net462\Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.Design.2.8.0\lib\net462\Bonsai.Scripting.Expressions.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.0\lib\net462\Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.1\lib\net462\Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages\Bonsai.System.Design.2.8.0\lib\net462\Bonsai.System.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.0\lib\net462\Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.0\lib\net462\Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.1\lib\net462\Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.1\lib\net462\Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll" />
@@ -67,11 +72,16 @@
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages\OpenTK.GLControl.3.1.0\lib\net20\OpenTK.GLControl.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll" />
+    <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll" />
+    <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages\System.Memory.4.5.5\lib\net461\System.Memory.dll" />
+    <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Interfaces" processorArchitecture="MSIL" location="Packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Linq" processorArchitecture="MSIL" location="Packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll" />
     <AssemblyLocation assemblyName="System.Reactive.PlatformServices" processorArchitecture="MSIL" location="Packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll" />
+    <AssemblyLocation assemblyName="System.Resources.Extensions" processorArchitecture="MSIL" location="Packages\System.Resources.Extensions.8.0.0\lib\net462\System.Resources.Extensions.dll" />
+    <AssemblyLocation assemblyName="System.Runtime.CompilerServices.Unsafe" processorArchitecture="MSIL" location="Packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll" />
     <AssemblyLocation assemblyName="YamlDotNet" processorArchitecture="MSIL" location="Packages\YamlDotNet.13.1.1\lib\net47\YamlDotNet.dll" />
     <AssemblyLocation assemblyName="ZedGraph" processorArchitecture="MSIL" location="Packages\ZedGraph.5.1.7\lib\net35-Client\ZedGraph.dll" />
   </AssemblyLocations>


### PR DESCRIPTION
The bootstrapper was out of date with package dependencies, possibly causing issues with build and debugging under certain configurations. Updating to make sure everything is in sync.