### PR TITLE
Convert BreakoutAnalogOutput data to offset binary

### DIFF
--- a/OpenEphys.Onix1/BreakoutAnalogOutput.cs
+++ b/OpenEphys.Onix1/BreakoutAnalogOutput.cs
@@ -89,12 +89,9 @@ namespace OpenEphys.Onix1
                     var dataSize = outputBuffer.Step * outputBuffer.Rows;
 
                     // twos-complement to offset binary
-                    var dataPtr = (short *)outputBuffer.Data.ToPointer();
                     const short Mask = -32768;
-                    for (int i = 0; i < dataSize / sizeof(short); i++)
-                        *(dataPtr + i) ^= Mask;
-
-                     device.Write(outputBuffer.Data, dataSize);
+                    CV.XorS(outputBuffer, new Scalar(Mask, 0, 0), outputBuffer);
+                    device.Write(outputBuffer.Data, dataSize);
                 });
             });
         }

--- a/OpenEphys.Onix1/ConfigureBreakoutAnalogIO.cs
+++ b/OpenEphys.Onix1/ConfigureBreakoutAnalogIO.cs
@@ -281,6 +281,7 @@ namespace OpenEphys.Onix1
         // constants
         public const int ChannelCount = 12;
         public const int NumberOfDivisions = 1 << 16;
+        public const int DacMidScale = 1 << 15;
 
         // managed registers
         public const uint ENABLE = 0;


### PR DESCRIPTION
- Fixes #205 
- The analog outputs on the breakout board expect 16-bit words in offset binary
- We were using twos-complement. This fix converts all outgoing data to offset binary before the final calls to device.Write()