### PR TITLE
Expose headstage port status data stream

### DIFF
--- a/OpenEphys.Onix1/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix1/ConfigureFmcLinkController.cs
@@ -88,11 +88,47 @@ namespace OpenEphys.Onix1
 
         public const uint LINKSTATE_PP = 0x2; // parity check pass bit
         public const uint LINKSTATE_SL = 0x1; // SERDES lock bit
+
+        internal class NameConverter : DeviceNameConverter
+        {
+            public NameConverter()
+                : base(typeof(FmcLinkController))
+            {
+            }
+        }
     }
 
     internal enum HubConfiguration
     {
         Standard,
         Passthrough
+    }
+
+    /// <summary>
+    /// Specifies the headstage port status codes.
+    /// </summary>
+    [Flags]
+    public enum PortStatusCode : byte
+    {
+        /// <summary>
+        /// Specifies nominal communication status.
+        /// </summary>
+        Nominal = 0x0,
+        /// <summary>
+        /// Specifies a cyclic redundancy check failure.
+        /// </summary>
+        CrcError = 0x1,
+        /// <summary>
+        /// Specifies too many devices were indicated in the hub device table.
+        /// </summary>
+        TooManyDevices = 0x2,
+        /// <summary>
+        /// Specifies a hub initialization error.
+        /// </summary>
+        InitializationError = 0x4,
+        /// <summary>
+        /// Specifies the receipt of a badly formed data packet.
+        /// </summary>
+        BadPacketFormat = 0x8,
     }
 }

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eLinkController.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eLinkController.cs
@@ -29,7 +29,7 @@ namespace OpenEphys.Onix1
 
         void SetVoltage(DeviceContext device, double voltage)
         {
-            device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
+            device.WriteRegister(PortController.PORTVOLTAGE, 0);
             Thread.Sleep(200);
             device.WriteRegister(FmcLinkController.PORTVOLTAGE, (uint)(10 * voltage));
             Thread.Sleep(200);

--- a/OpenEphys.Onix1/PortStatus.cs
+++ b/OpenEphys.Onix1/PortStatus.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// A class that produces a sequence of port status information.
+    /// </summary>
+    /// <remarks>
+    /// This data stream class must be linked to an appropriate headstage, miniscope, or similar configuration.
+    /// </remarks>
+    [Description("Produces a sequence of port status information.")]
+    public class PortStatus : Source<PortStatusFrame>
+    {
+        /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
+        [TypeConverter(typeof(FmcLinkController.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
+        public string DeviceName { get; set; }
+
+        /// <summary>
+        /// Generates a sequence of <see cref="MemoryMonitorDataFrame"/> objects, which contains information
+        /// about the system's low-level first-in, first-out (FIFO) data buffer.
+        /// </summary>
+        /// <returns>A sequence of <see cref="MemoryMonitorDataFrame"/> objects.</returns>
+        public override IObservable<PortStatusFrame> Generate()
+        {
+            return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
+            {
+                var device = deviceInfo.GetDeviceContext(typeof(FmcLinkController));
+
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
+                    .Select(frame => new PortStatusFrame(frame));
+            });
+        }
+    }
+}

--- a/OpenEphys.Onix1/PortStatusFrame.cs
+++ b/OpenEphys.Onix1/PortStatusFrame.cs
@@ -1,0 +1,56 @@
+﻿using System.Runtime.InteropServices;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// A class that contains hardware memory use information.
+    /// </summary>
+    public class PortStatusFrame : DataFrame
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryMonitorDataFrame"/> class.
+        /// </summary>
+        /// <param name="frame">A data frame produced by a memory monitor device.</param>
+        /// <param name="totalMemory">
+        /// The total amount of memory, in 32-bit words, on the hardware that is available for data buffering.
+        /// </param>
+        public unsafe PortStatusFrame(oni.Frame frame)
+            : base(frame.Clock)
+        {
+            var payload = (PortStatusPayload*)frame.Data.ToPointer();
+            HubClock = payload->HubClock;
+            StatusCode = payload->Code;
+            StatusCodeValid = (payload->DeserializerStatus & 0x0004) == 4;
+            SerdesLocked = (payload->DeserializerStatus & 0x0001) == 1;
+            SerdesPass = (payload->DeserializerStatus & 0x0002) == 2;
+        }
+
+        /// <summary>
+        /// Gets the 
+        /// </summary>
+        public PortStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets the 
+        /// </summary>
+        public bool StatusCodeValid { get; }
+
+        /// <summary>
+        /// Gets the 
+        /// </summary>
+        public bool SerdesLocked { get; }
+
+        /// <summary>
+        /// Gets the 
+        /// </summary>
+        public bool SerdesPass { get; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct PortStatusPayload
+    {
+        public ulong HubClock;
+        public PortStatusCode Code;
+        public byte DeserializerStatus;
+    }
+}


### PR DESCRIPTION
- Fixes #156
- I feel that FmcLinkController  and ConfigureFmcLinkController should be renamed PortController and ConfigurePortController, respectively to match their implicity configurate via the "Port" property in headstages and miniscopes, as well as their labelling on the hardware