### PR TITLE
Expose headstage port status data stream

### DIFF
--- a/OpenEphys.Onix1/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64.cs
@@ -5,13 +5,13 @@ using System.Threading;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// A class that configures an ONIX headstage-64 in the specified port.
+    /// A class that configures an ONIX headstage-64 on the specified port.
     /// </summary>
     [Description("Configures an ONIX headstage-64 in the specified port.")]
     public class ConfigureHeadstage64 : MultiDeviceFactory
     {
         PortName port;
-        readonly ConfigureHeadstage64LinkController LinkController = new();
+        readonly ConfigureHeadstage64PortController LinkController = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigureHeadstage64"/> class.
@@ -136,7 +136,7 @@ namespace OpenEphys.Onix1
             yield return OpticalStimulator;
         }
 
-        class ConfigureHeadstage64LinkController : ConfigureFmcLinkController
+        class ConfigureHeadstage64PortController : ConfigurePortController
         {
             protected override bool ConfigurePortVoltage(DeviceContext device)
             {
@@ -153,7 +153,7 @@ namespace OpenEphys.Onix1
                 var voltage = MaxVoltage;
                 for (; voltage >= MinVoltage; voltage -= VoltageIncrement)
                 {
-                    device.WriteRegister(FmcLinkController.PORTVOLTAGE, voltage);
+                    device.WriteRegister(PortController.PORTVOLTAGE, voltage);
                     Thread.Sleep(200);
                     if (!CheckLinkState(device))
                     {
@@ -162,32 +162,15 @@ namespace OpenEphys.Onix1
                     }
                 }
 
-                device.WriteRegister(FmcLinkController.PORTVOLTAGE, MinVoltage);
-                device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
+                device.WriteRegister(PortController.PORTVOLTAGE, MinVoltage);
+                device.WriteRegister(PortController.PORTVOLTAGE, 0);
                 Thread.Sleep(1000);
-                device.WriteRegister(FmcLinkController.PORTVOLTAGE, voltage + VoltageOffset);
+                device.WriteRegister(PortController.PORTVOLTAGE, voltage + VoltageOffset);
                 Thread.Sleep(200);
                 return CheckLinkState(device);
             }
         }
     }
 
-    /// <summary>
-    /// Specifies the physical port that a headstage is plugged into.
-    /// </summary>
-    /// <remarks>
-    /// ONIX uses a common protocol to communicate with a variety of devices using the same physical connection. For this reason
-    /// lots of different headstage types can be plugged into a headstage port.
-    /// </remarks>
-    public enum PortName
-    {
-        /// <summary>
-        /// Specifies Port A.
-        /// </summary>
-        PortA = 1,
-        /// <summary>
-        /// Specifies Port B.
-        /// </summary>
-        PortB = 2
-    }
+
 }

--- a/OpenEphys.Onix1/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     public class ConfigureHeadstage64 : MultiDeviceFactory
     {
         PortName port;
-        readonly ConfigureHeadstage64PortController LinkController = new();
+        readonly ConfigureHeadstage64PortController PortControl = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigureHeadstage64"/> class.
@@ -35,7 +35,7 @@ namespace OpenEphys.Onix1
             // The FMC port voltage can only go down to 3.3V, which means that its very hard to find the true lowest voltage
             // for a lock and then add a large offset to that. Fixing this requires a hardware change.
             Port = PortName.PortA;
-            LinkController.HubConfiguration = HubConfiguration.Standard;
+            PortControl.HubConfiguration = HubConfiguration.Standard;
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace OpenEphys.Onix1
             {
                 port = value;
                 var offset = (uint)port << 8;
-                LinkController.DeviceAddress = (uint)port;
+                PortControl.DeviceAddress = (uint)port;
                 Rhd2164.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
                 TS4231.DeviceAddress = offset + 2;
@@ -122,13 +122,13 @@ namespace OpenEphys.Onix1
                      "Supplying higher voltages may result in damage to the headstage.")]
         public double? PortVoltage
         {
-            get => LinkController.PortVoltage;
-            set => LinkController.PortVoltage = value;
+            get => PortControl.PortVoltage;
+            set => PortControl.PortVoltage = value;
         }
 
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
-            yield return LinkController;
+            yield return PortControl;
             yield return Rhd2164;
             yield return Bno055;
             yield return TS4231;

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1eHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1eHeadstage.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     public class ConfigureNeuropixelsV1eHeadstage : MultiDeviceFactory
     {
         PortName port;
-        readonly ConfigureNeuropixelsV1ePortController LinkController = new();
+        readonly ConfigureNeuropixelsV1ePortController PortControl = new();
 
         /// <summary>
         /// Initialize a new instance of a <see cref="ConfigureNeuropixelsV1eHeadstage"/> class.
@@ -19,7 +19,7 @@ namespace OpenEphys.Onix1
         public ConfigureNeuropixelsV1eHeadstage()
         {
             Port = PortName.PortA;
-            LinkController.HubConfiguration = HubConfiguration.Passthrough;
+            PortControl.HubConfiguration = HubConfiguration.Passthrough;
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace OpenEphys.Onix1
             {
                 port = value;
                 var offset = (uint)port << 8;
-                LinkController.DeviceAddress = (uint)port;
+                PortControl.DeviceAddress = (uint)port;
                 NeuropixelsV1e.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
             }
@@ -72,13 +72,13 @@ namespace OpenEphys.Onix1
             "for proper operation. Higher voltages can damage the headstage.")]
         public double? PortVoltage
         {
-            get => LinkController.PortVoltage;
-            set => LinkController.PortVoltage = value;
+            get => PortControl.PortVoltage;
+            set => PortControl.PortVoltage = value;
         }
 
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
-            yield return LinkController;
+            yield return PortControl;
             yield return NeuropixelsV1e;
             yield return Bno055;
         }

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1eHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1eHeadstage.cs
@@ -5,13 +5,13 @@ using System.Threading;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// A class that configures a NeuropixelsV1e headstage.
+    /// A class that configures a NeuropixelsV1e headstage on the specified port.
     /// </summary>
     [Description("Configures a NeuropixelsV1e headstage.")]
     public class ConfigureNeuropixelsV1eHeadstage : MultiDeviceFactory
     {
         PortName port;
-        readonly ConfigureNeuropixelsV1eLinkController LinkController = new();
+        readonly ConfigureNeuropixelsV1ePortController LinkController = new();
 
         /// <summary>
         /// Initialize a new instance of a <see cref="ConfigureNeuropixelsV1eHeadstage"/> class.
@@ -83,7 +83,7 @@ namespace OpenEphys.Onix1
             yield return Bno055;
         }
 
-        class ConfigureNeuropixelsV1eLinkController : ConfigureFmcLinkController
+        class ConfigureNeuropixelsV1ePortController : ConfigurePortController
         {
             protected override bool ConfigurePortVoltage(DeviceContext device)
             {
@@ -108,9 +108,9 @@ namespace OpenEphys.Onix1
 
             void SetVoltage(DeviceContext device, double voltage)
             {
-                device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
+                device.WriteRegister(PortController.PORTVOLTAGE, 0);
                 Thread.Sleep(200);
-                device.WriteRegister(FmcLinkController.PORTVOLTAGE, (uint)(10 * voltage));
+                device.WriteRegister(PortController.PORTVOLTAGE, (uint)(10 * voltage));
                 Thread.Sleep(200);
             }
         }

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBetaHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBetaHeadstage.cs
@@ -4,13 +4,13 @@ using System.ComponentModel;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// A class that configures a NeuropixelsV2eBeta headstage.
+    /// A class that configures a NeuropixelsV2eBeta headstage on the specified port.
     /// </summary>
     [Description("Configures a NeuropixelsV2eBeta headstage.")]
     public class ConfigureNeuropixelsV2eBetaHeadstage : MultiDeviceFactory
     {
         PortName port;
-        readonly ConfigureNeuropixelsV2eLinkController LinkController = new();
+        readonly ConfigureNeuropixelsV2ePortController LinkController = new();
 
         /// <summary>
         /// Initialize a new instance of a <see cref="ConfigureNeuropixelsV2eBetaHeadstage"/> class.

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBetaHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBetaHeadstage.cs
@@ -10,7 +10,7 @@ namespace OpenEphys.Onix1
     public class ConfigureNeuropixelsV2eBetaHeadstage : MultiDeviceFactory
     {
         PortName port;
-        readonly ConfigureNeuropixelsV2ePortController LinkController = new();
+        readonly ConfigureNeuropixelsV2ePortController PortControl = new();
 
         /// <summary>
         /// Initialize a new instance of a <see cref="ConfigureNeuropixelsV2eBetaHeadstage"/> class.
@@ -18,7 +18,7 @@ namespace OpenEphys.Onix1
         public ConfigureNeuropixelsV2eBetaHeadstage()
         {
             Port = PortName.PortA;
-            LinkController.HubConfiguration = HubConfiguration.Passthrough;
+            PortControl.HubConfiguration = HubConfiguration.Passthrough;
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace OpenEphys.Onix1
             {
                 port = value;
                 var offset = (uint)port << 8;
-                LinkController.DeviceAddress = (uint)port;
+                PortControl.DeviceAddress = (uint)port;
                 NeuropixelsV2eBeta.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
             }
@@ -71,13 +71,13 @@ namespace OpenEphys.Onix1
             "for proper operation. Higher voltages can damage the headstage.")]
         public double? PortVoltage
         {
-            get => LinkController.PortVoltage;
-            set => LinkController.PortVoltage = value;
+            get => PortControl.PortVoltage;
+            set => PortControl.PortVoltage = value;
         }
 
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
-            yield return LinkController;
+            yield return PortControl;
             yield return NeuropixelsV2eBeta;
             yield return Bno055;
         }

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eHeadstage.cs
@@ -4,13 +4,13 @@ using System.ComponentModel;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// A class that configures a NeuropixelsV2e headstage.
+    /// A class that configures a NeuropixelsV2e headstage on the specified port.
     /// </summary>
     [Description("configures a NeuropixelsV2e headstage.")]
     public class ConfigureNeuropixelsV2eHeadstage : MultiDeviceFactory
     {
         PortName port;
-        readonly ConfigureNeuropixelsV2eLinkController LinkController = new();
+        readonly ConfigureNeuropixelsV2ePortController LinkController = new();
 
         /// <summary>
         /// Initialize a new instance of a <see cref="ConfigureNeuropixelsV2e"/> class.

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eHeadstage.cs
@@ -10,7 +10,7 @@ namespace OpenEphys.Onix1
     public class ConfigureNeuropixelsV2eHeadstage : MultiDeviceFactory
     {
         PortName port;
-        readonly ConfigureNeuropixelsV2ePortController LinkController = new();
+        readonly ConfigureNeuropixelsV2ePortController PortControl = new();
 
         /// <summary>
         /// Initialize a new instance of a <see cref="ConfigureNeuropixelsV2e"/> class.
@@ -18,7 +18,7 @@ namespace OpenEphys.Onix1
         public ConfigureNeuropixelsV2eHeadstage()
         {
             Port = PortName.PortA;
-            LinkController.HubConfiguration = HubConfiguration.Passthrough;
+            PortControl.HubConfiguration = HubConfiguration.Passthrough;
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace OpenEphys.Onix1
             {
                 port = value;
                 var offset = (uint)port << 8;
-                LinkController.DeviceAddress = (uint)port;
+                PortControl.DeviceAddress = (uint)port;
                 NeuropixelsV2e.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
             }
@@ -71,13 +71,13 @@ namespace OpenEphys.Onix1
             "for proper operation. Higher voltages can damage the headstage.")]
         public double? PortVoltage
         {
-            get => LinkController.PortVoltage;
-            set => LinkController.PortVoltage = value;
+            get => PortControl.PortVoltage;
+            set => PortControl.PortVoltage = value;
         }
 
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
-            yield return LinkController;
+            yield return PortControl;
             yield return NeuropixelsV2e;
             yield return Bno055;
         }

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2ePortController.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2ePortController.cs
@@ -2,7 +2,7 @@
 
 namespace OpenEphys.Onix1
 {
-    class ConfigureNeuropixelsV2eLinkController : ConfigureFmcLinkController
+    class ConfigureNeuropixelsV2ePortController : ConfigurePortController
     {
 
         protected override bool ConfigurePortVoltage(DeviceContext device)
@@ -29,9 +29,9 @@ namespace OpenEphys.Onix1
 
         void SetVoltage(DeviceContext device, double voltage)
         {
-            device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
+            device.WriteRegister(PortController.PORTVOLTAGE, 0);
             Thread.Sleep(200);
-            device.WriteRegister(FmcLinkController.PORTVOLTAGE, (uint)(10 * voltage));
+            device.WriteRegister(PortController.PORTVOLTAGE, (uint)(10 * voltage));
             Thread.Sleep(200);
         }
     }

--- a/OpenEphys.Onix1/ConfigurePortController.cs
+++ b/OpenEphys.Onix1/ConfigurePortController.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Reactive.Disposables;
+using System.Reflection;
 using System.Threading;
 
 namespace OpenEphys.Onix1
 {
-    internal abstract class ConfigureFmcLinkController : SingleDeviceFactory
+    internal abstract class ConfigurePortController : SingleDeviceFactory
     {
-        public ConfigureFmcLinkController()
-            : base(typeof(FmcLinkController))
+        public ConfigurePortController()
+            : base(typeof(PortController))
         {
         }
 
@@ -23,15 +24,15 @@ namespace OpenEphys.Onix1
 
         protected virtual bool CheckLinkState(DeviceContext device)
         {
-            var linkState = device.ReadRegister(FmcLinkController.LINKSTATE);
-            return (linkState & FmcLinkController.LINKSTATE_SL) != 0;
+            var linkState = device.ReadRegister(PortController.LINKSTATE);
+            return (linkState & PortController.LINKSTATE_SL) != 0;
         }
 
         protected abstract bool ConfigurePortVoltage(DeviceContext device);
 
         private bool ConfigurePortVoltageOverride(DeviceContext device, double voltage)
         {
-            device.WriteRegister(FmcLinkController.PORTVOLTAGE, (uint)(voltage * 10));
+            device.WriteRegister(PortController.PORTVOLTAGE, (uint)(voltage * 10));
             Thread.Sleep(500);
             return CheckLinkState(device);
         }
@@ -44,7 +45,7 @@ namespace OpenEphys.Onix1
             var portVoltage = PortVoltage;
             return source.ConfigureHost(context =>
             {
-                // configure passthrough mode on the FMC link controller
+                // configure passthrough mode on the port controller
                 // assuming the device address is the port number
                 var portShift = ((int)deviceAddress - 1) * 2;
                 var passthroughState = (hubConfiguration == HubConfiguration.Passthrough ? 1 : 0) << portShift;
@@ -54,8 +55,8 @@ namespace OpenEphys.Onix1
             .ConfigureLink(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
-                void dispose() => device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
-                device.WriteRegister(FmcLinkController.ENABLE, 1);
+                void dispose() => device.WriteRegister(PortController.PORTVOLTAGE, 0);
+                device.WriteRegister(PortController.ENABLE, 1);
 
                 var serdesLock = portVoltage.HasValue
                     ? ConfigurePortVoltageOverride(device, portVoltage.GetValueOrDefault())
@@ -63,7 +64,12 @@ namespace OpenEphys.Onix1
                 if (!serdesLock)
                 {
                     dispose();
-                    throw new InvalidOperationException("Unable to get SERDES lock on FMC link controller.");
+                    var port = (PortName)deviceAddress;
+                    var portString = port.GetType()
+                                         .GetField(port.ToString())?
+                                         .GetCustomAttribute<DescriptionAttribute>()?
+                                         .Description ?? "Address " + deviceAddress.ToString();
+                    throw new InvalidOperationException($"Unable to acquire communication lock on {portString}.");
                 }
                 return Disposable.Create(dispose);
             })
@@ -75,7 +81,7 @@ namespace OpenEphys.Onix1
         }
     }
 
-    internal static class FmcLinkController
+    internal static class PortController
     {
         public const int ID = 23;
 
@@ -88,11 +94,68 @@ namespace OpenEphys.Onix1
 
         public const uint LINKSTATE_PP = 0x2; // parity check pass bit
         public const uint LINKSTATE_SL = 0x1; // SERDES lock bit
+
+        internal class NameConverter : DeviceNameConverter
+        {
+            public NameConverter()
+                : base(typeof(PortController))
+            {
+            }
+        }
     }
 
     internal enum HubConfiguration
     {
         Standard,
         Passthrough
+    }
+
+    /// <summary>
+    /// Specifies the headstage port status codes.
+    /// </summary>
+    [Flags]
+    public enum PortStatusCode : byte
+    {
+        /// <summary>
+        /// Specifies that the status code should be disregarded.
+        /// </summary>
+        Invalid = 0x0,
+        /// <summary>
+        /// Specifies a cyclic redundancy check failure.
+        /// </summary>
+        CrcError = 0x1,
+        /// <summary>
+        /// Specifies that too many devices were indicated in the hub device table.
+        /// </summary>
+        TooManyDevices = 0x2,
+        /// <summary>
+        /// Specifies a hub initialization error.
+        /// </summary>
+        InitializationError = 0x4,
+        /// <summary>
+        /// Specifies the receipt of a badly formatted data packet.
+        /// </summary>
+        BadPacketFormat = 0x8,
+    }
+
+    /// <summary>
+    /// Specifies the physical port that a headstage is plugged into.
+    /// </summary>
+    /// <remarks>
+    /// ONIX uses a common protocol to communicate with a variety of devices using the same physical connection. For this reason
+    /// lots of different headstage types can be plugged into a headstage port.
+    /// </remarks>
+    public enum PortName
+    {
+        /// <summary>
+        /// Specifies Port A.
+        /// </summary>
+        [Description("Port A")]
+        PortA = 1,
+        /// <summary>
+        /// Specifies Port B.
+        /// </summary>
+        [Description("Port B")]
+        PortB = 2
     }
 }

--- a/OpenEphys.Onix1/PortStatus.cs
+++ b/OpenEphys.Onix1/PortStatus.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// A class that produces a sequence of port status information frames.
+    /// </summary>
+    /// <remarks>
+    /// This data stream class must be linked to an appropriate headstage,
+    /// miniscope, etc. configuration whose communication is dictated by
+    /// a <see cref="PortController"/>.
+    /// </remarks>
+    [Description("Produces a sequence of port status information.")]
+    public class PortStatus : Source<PortStatusFrame>
+    {
+        /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
+        [TypeConverter(typeof(PortController.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
+        public string DeviceName { get; set; }
+
+        /// <summary>
+        /// Generates a sequence of <see cref="PortStatusFrame"/> objects, which contains information
+        /// about the the a headstage port communication status.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="PortStatusFrame"/> will be produced only in exceptional circumstances. For
+        /// instance,  when the headstage becomes disconnected, a packet fails a CRC check, etc.
+        /// </remarks>
+        /// <returns>A sequence of <see cref="PortStatusFrame"/> objects.</returns>
+        public override IObservable<PortStatusFrame> Generate()
+        {
+            return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
+            {
+                var device = deviceInfo.GetDeviceContext(typeof(PortController));
+
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
+                    .Select(frame => new PortStatusFrame(frame));
+            });
+        }
+    }
+}

--- a/OpenEphys.Onix1/PortStatusFrame.cs
+++ b/OpenEphys.Onix1/PortStatusFrame.cs
@@ -1,0 +1,48 @@
+﻿using System.Runtime.InteropServices;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// A class that contains port status information.
+    /// </summary>
+    public class PortStatusFrame : DataFrame
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PortStatusFrame"/> class.
+        /// </summary>
+        /// <param name="frame">A data frame produced by a port controller device.</param>
+        public unsafe PortStatusFrame(oni.Frame frame)
+            : base(frame.Clock)
+        {
+            var payload = (PortStatusPayload*)frame.Data.ToPointer();
+            HubClock = payload->HubClock;
+            var statusCodeValid = (payload->SerdesStatus & 0x0004) == 4;
+            StatusCode = statusCodeValid ? payload->Code : PortStatusCode.Invalid;
+            SerdesLocked = (payload->SerdesStatus & 0x0001) == 1;
+            SerdesPass = (payload->SerdesStatus & 0x0002) == 2;
+        }
+
+        /// <summary>
+        /// Gets the port status code.
+        /// </summary>
+        public PortStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets the SERDES forward channel lock status.
+        /// </summary>
+        public bool SerdesLocked { get; }
+
+        /// <summary>
+        /// Gets the SERDES on-chip parity check status.
+        /// </summary>
+        public bool SerdesPass { get; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct PortStatusPayload
+    {
+        public ulong HubClock;
+        public PortStatusCode Code;
+        public byte SerdesStatus;
+    }
+}


### PR DESCRIPTION
- Fixes #156
- Rename `*FmcLink*` to `*Port*`
- Improve error string when SERDES lock cannot be established
- Move PortName enum into ConfigurePortController.cs