### PR TITLE
Propogate boolean in Headstage64 stimulator triggers

### DIFF
--- a/OpenEphys.Onix1/Headstage64ElectricalStimulatorTrigger.cs
+++ b/OpenEphys.Onix1/Headstage64ElectricalStimulatorTrigger.cs
@@ -208,7 +208,11 @@ namespace OpenEphys.Onix1
                 {
                     var device = deviceInfo.GetDeviceContext(typeof(Headstage64ElectricalStimulator));
                     var triggerObserver = Observer.Create<bool>(
-                        value => device.WriteRegister(Headstage64ElectricalStimulator.TRIGGER, value ? 1u : 0u),
+                        value =>
+                        {
+                            device.WriteRegister(Headstage64ElectricalStimulator.TRIGGER, value ? 1u : 0u);
+                            observer.OnNext(value);
+                        },
                         observer.OnError,
                         observer.OnCompleted);
 

--- a/OpenEphys.Onix1/Headstage64OpticalStimulatorTrigger.cs
+++ b/OpenEphys.Onix1/Headstage64OpticalStimulatorTrigger.cs
@@ -202,7 +202,11 @@ namespace OpenEphys.Onix1
                 {
                     var device = deviceInfo.GetDeviceContext(typeof(Headstage64OpticalStimulator));
                     var triggerObserver = Observer.Create<bool>(
-                        value => device.WriteRegister(Headstage64OpticalStimulator.TRIGGER, value ? 1u : 0u),
+                        value =>
+                        {
+                            device.WriteRegister(Headstage64OpticalStimulator.TRIGGER, value ? 1u : 0u);
+                            observer.OnNext(value);
+                        },
                         observer.OnError,
                         observer.OnCompleted);
 


### PR DESCRIPTION
- These operators were not acting as sinks because they were not propogating their observable sequence
- Fixes #83