### PR TITLE
Implement ConfigureNeuropixelV1/2eBno055.Enable

### DIFF
--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1eBno055.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1eBno055.cs
@@ -51,7 +51,7 @@ namespace OpenEphys.Onix1
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
                 ConfigureDeserializer(device);
                 ConfigureBno055(device);
-                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
+                var deviceInfo = new NeuropixelsV1eBno055DeviceInfo(context, DeviceType, deviceAddress, enable);
                 return DeviceManager.RegisterDevice(deviceName, deviceInfo);
             });
         }
@@ -90,5 +90,16 @@ namespace OpenEphys.Onix1
             {
             }
         }
+    }
+
+    class NeuropixelsV1eBno055DeviceInfo : DeviceInfo
+    {
+        public NeuropixelsV1eBno055DeviceInfo(ContextTask context, Type deviceType, uint deviceAddress, bool enable)
+            : base(context, deviceType, deviceAddress)
+        {
+            Enable = enable;
+        }
+
+        public bool Enable { get; }
     }
 }

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBno055.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBno055.cs
@@ -51,7 +51,7 @@ namespace OpenEphys.Onix1
                 var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
                 ConfigureDeserializer(device);
                 ConfigureBno055(device);
-                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
+                var deviceInfo = new NeuropixelsV2eBno055DeviceInfo(context, DeviceType, deviceAddress, enable);
                 return DeviceManager.RegisterDevice(deviceName, deviceInfo);
             });
         }
@@ -90,5 +90,16 @@ namespace OpenEphys.Onix1
             {
             }
         }
+    }
+
+    class NeuropixelsV2eBno055DeviceInfo : DeviceInfo
+    {
+        public NeuropixelsV2eBno055DeviceInfo(ContextTask context, Type deviceType, uint deviceAddress, bool enable)
+            : base(context, deviceType, deviceAddress)
+        {
+            Enable = enable;
+        }
+
+        public bool Enable { get; }
     }
 }

--- a/OpenEphys.Onix1/NeuropixelsV2eBno055Data.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBno055Data.cs
@@ -39,32 +39,37 @@ namespace OpenEphys.Onix1
         public unsafe IObservable<Bno055DataFrame> Generate<TSource>(IObservable<TSource> source)
         {
             return DeviceManager.GetDevice(DeviceName).SelectMany(
-                deviceInfo => Observable.Create<Bno055DataFrame>(observer =>
+                deviceInfo =>
                 {
-                    var device = deviceInfo.GetDeviceContext(typeof(NeuropixelsV2eBno055));
-                    var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
-                    var i2c = new I2CRegisterContext(passthrough, NeuropixelsV2eBno055.BNO055Address);
-
-                    return source.SubscribeSafe(observer, _ =>
-                    {
-                        Bno055DataFrame frame = default;
-                        device.Context.EnsureContext(() =>
+                    return !((NeuropixelsV2eBno055DeviceInfo)deviceInfo).Enable
+                        ? Observable.Empty<Bno055DataFrame>()
+                        : Observable.Create<Bno055DataFrame>(observer =>
                         {
-                            var data = i2c.ReadBytes(NeuropixelsV2eBno055.DataAddress, sizeof(Bno055DataPayload));
-                            ulong clock = passthrough.ReadRegister(DS90UB9x.LASTI2CL);
-                            clock += (ulong)passthrough.ReadRegister(DS90UB9x.LASTI2CH) << 32;
-                            fixed (byte* dataPtr = data)
+                            var device = deviceInfo.GetDeviceContext(typeof(NeuropixelsV2eBno055));
+                            var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
+                            var i2c = new I2CRegisterContext(passthrough, NeuropixelsV2eBno055.BNO055Address);
+
+                            return source.SubscribeSafe(observer, _ =>
                             {
-                                frame = new Bno055DataFrame(clock, (Bno055DataPayload*)dataPtr);
-                            }
-                        });
+                                Bno055DataFrame frame = default;
+                                device.Context.EnsureContext(() =>
+                                {
+                                    var data = i2c.ReadBytes(NeuropixelsV2eBno055.DataAddress, sizeof(Bno055DataPayload));
+                                    ulong clock = passthrough.ReadRegister(DS90UB9x.LASTI2CL);
+                                    clock += (ulong)passthrough.ReadRegister(DS90UB9x.LASTI2CH) << 32;
+                                    fixed (byte* dataPtr = data)
+                                    {
+                                        frame = new Bno055DataFrame(clock, (Bno055DataPayload*)dataPtr);
+                                    }
+                                });
 
-                        if (frame != null)
-                        {
-                            observer.OnNext(frame);
-                        }
-                    });
-                }));
+                                if (frame != null)
+                                {
+                                    observer.OnNext(frame);
+                                }
+                            });
+                        });
+                });
         }
     }
 }


### PR DESCRIPTION
- Fixes #191
- Previously ConfigureNeuropixelV1/2eBno055.Enable was not doing anything
- Now enable state is passed through a custom DeviceInfo object to the NeuropixelV1/2eBno055Data operator. If its false, the operator returns an Observable.Empty<Bno055DataFrame>.