### PR TITLE
Add more informative titles to project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-.vs/
+.vs*/
 /artifacts/
 .bonsai/Packages/
 .bonsai/*.exe
 .bonsai/*.exe.settings
 .bonsai/*.exe.WebView2/
+*.user

--- a/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
+++ b/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Title>OpenEphys.Onix1.Design</Title>
+    <Title>Bonsai Onix1 Design Library - Open Ephys</Title>
     <Description>Bonsai Library containing visual interfaces for configuring ONIX devices.</Description>
     <PackageTags>Bonsai Rx Open Ephys Onix Design</PackageTags>
     <TargetFramework>net472</TargetFramework>

--- a/OpenEphys.Onix1/OpenEphys.Onix1.csproj
+++ b/OpenEphys.Onix1/OpenEphys.Onix1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Title>OpenEphys.Onix1</Title>
+    <Title>Bonsai Onix1 - Open Ephys</Title>
     <Description>Bonsai library containing interfaces for data acquisition and control of ONIX devices.</Description>
     <PackageTags>Bonsai Rx Open Ephys Onix</PackageTags>
     <TargetFramework>net472</TargetFramework>


### PR DESCRIPTION
Instead of using the namespace as the title for each project (i.e., `OpenEphys.Onix1`), give a more informative and user-friendly title (e.g., `Bonsai Onix1 - Open Ephys`).