### PR TITLE
Add visualizers for Quaternion and Vector3

### DIFF
--- a/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
+++ b/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Design" Version="2.8.5" />
+    <PackageReference Include="Bonsai.Design.Visualizers" Version="2.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.1.0" />
     <PackageReference Include="ZedGraph" Version="5.1.7" />

--- a/OpenEphys.Onix1.Design/QuaternionVisualizer.cs
+++ b/OpenEphys.Onix1.Design/QuaternionVisualizer.cs
@@ -2,11 +2,11 @@
 using Bonsai;
 using Bonsai.Design.Visualizers;
 using System.Numerics;
-using Bonsai.Vision.Design;
+using OpenEphys.Onix1.Design;
 
 [assembly: TypeVisualizer(typeof(QuaternionVisualizer), Target = typeof(Quaternion))]
 
-namespace Bonsai.Vision.Design
+namespace OpenEphys.Onix1.Design
 {
     /// <summary>
     /// Provides a type visualizer that displays a sequence of <see cref="Quaternion"/>

--- a/OpenEphys.Onix1.Design/QuaternionVisualizer.cs
+++ b/OpenEphys.Onix1.Design/QuaternionVisualizer.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Bonsai;
+using Bonsai.Design.Visualizers;
+using System.Numerics;
+using Bonsai.Vision.Design;
+
+[assembly: TypeVisualizer(typeof(QuaternionVisualizer), Target = typeof(Quaternion))]
+
+namespace Bonsai.Vision.Design
+{
+    /// <summary>
+    /// Provides a type visualizer that displays a sequence of <see cref="Quaternion"/>
+    /// values as a time series.
+    /// </summary>
+    public class QuaternionVisualizer : TimeSeriesVisualizer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuaternionVisualizer"/> class.
+        /// </summary>
+        public QuaternionVisualizer()
+            : base(numSeries: 4)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            var q = (Quaternion)value;
+            AddValue(DateTime.Now, q.X, q.Y, q.Z, q.W);
+        }
+    }
+}

--- a/OpenEphys.Onix1.Design/Vector3Visualizer.cs
+++ b/OpenEphys.Onix1.Design/Vector3Visualizer.cs
@@ -2,11 +2,11 @@
 using Bonsai;
 using Bonsai.Design.Visualizers;
 using System.Numerics;
-using Bonsai.Vision.Design;
+using OpenEphys.Onix1.Design;
 
 [assembly: TypeVisualizer(typeof(Vector3Visualizer), Target = typeof(Vector3))]
 
-namespace Bonsai.Vision.Design
+namespace OpenEphys.Onix1.Design
 {
     /// <summary>
     /// Provides a type visualizer that displays a sequence of <see cref="Vector3"/>

--- a/OpenEphys.Onix1.Design/Vector3Visualizer.cs
+++ b/OpenEphys.Onix1.Design/Vector3Visualizer.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Bonsai;
+using Bonsai.Design.Visualizers;
+using System.Numerics;
+using Bonsai.Vision.Design;
+
+[assembly: TypeVisualizer(typeof(Vector3Visualizer), Target = typeof(Vector3))]
+
+namespace Bonsai.Vision.Design
+{
+    /// <summary>
+    /// Provides a type visualizer that displays a sequence of <see cref="Vector3"/>
+    /// values as a time series.
+    /// </summary>
+    public class Vector3Visualizer : TimeSeriesVisualizer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3Visualizer"/> class.
+        /// </summary>
+        public Vector3Visualizer()
+            : base(numSeries: 3)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            var v = (Vector3)value;
+            AddValue(DateTime.Now, v.X, v.Y, v.Z);
+        }
+    }
+}


### PR DESCRIPTION
- Both of these System.Numerics types are used data frames (Bno055DataFrame and TS4231V1PositionDataFrame)
- Fixes #136