### PR TITLE
Remove link to internal PortController class

### DIFF
--- a/OpenEphys.Onix1/PortStatus.cs
+++ b/OpenEphys.Onix1/PortStatus.cs
@@ -12,7 +12,7 @@ namespace OpenEphys.Onix1
     /// <remarks>
     /// This data stream class must be linked to an appropriate headstage,
     /// miniscope, etc. configuration whose communication is dictated by
-    /// a <see cref="PortController"/>.
+    /// a PortController.
     /// </remarks>
     [Description("Produces a sequence of port status information.")]
     public class PortStatus : Source<PortStatusFrame>


### PR DESCRIPTION
When building the docfx website, we do not render private or internal classes, leading to a broken reference.

A broken reference blocks that repo from merging pull requests, therefore we need to remove this reference.