### PR TITLE
Modify NeuropixelsV2e dialogs to scale correctly

### DIFF
--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
@@ -31,17 +31,14 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NeuropixelsV2eDialog));
             this.menuStrip = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tabControlProbe = new System.Windows.Forms.TabControl();
-            this.panel1 = new System.Windows.Forms.Panel();
             this.buttonCancel = new System.Windows.Forms.Button();
             this.buttonOkay = new System.Windows.Forms.Button();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.menuStrip.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-            this.splitContainer1.Panel1.SuspendLayout();
-            this.splitContainer1.Panel2.SuspendLayout();
-            this.splitContainer1.SuspendLayout();
-            this.panel1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // menuStrip
@@ -52,7 +49,7 @@
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
             this.menuStrip.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(843, 24);
+            this.menuStrip.Size = new System.Drawing.Size(854, 24);
             this.menuStrip.TabIndex = 0;
             this.menuStrip.Text = "menuStripNeuropixelsV2e";
             // 
@@ -62,55 +59,22 @@
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
-            // splitContainer1
-            // 
-            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 24);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(2);
-            this.splitContainer1.Name = "splitContainer1";
-            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // splitContainer1.Panel1
-            // 
-            this.splitContainer1.Panel1.Controls.Add(this.tabControlProbe);
-            // 
-            // splitContainer1.Panel2
-            // 
-            this.splitContainer1.Panel2.Controls.Add(this.panel1);
-            this.splitContainer1.Size = new System.Drawing.Size(843, 506);
-            this.splitContainer1.SplitterDistance = 477;
-            this.splitContainer1.SplitterWidth = 3;
-            this.splitContainer1.TabIndex = 2;
-            // 
             // tabControlProbe
             // 
             this.tabControlProbe.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControlProbe.Location = new System.Drawing.Point(0, 0);
+            this.tabControlProbe.Location = new System.Drawing.Point(2, 2);
             this.tabControlProbe.Margin = new System.Windows.Forms.Padding(2);
             this.tabControlProbe.Name = "tabControlProbe";
             this.tabControlProbe.SelectedIndex = 0;
-            this.tabControlProbe.Size = new System.Drawing.Size(843, 477);
+            this.tabControlProbe.Size = new System.Drawing.Size(850, 510);
             this.tabControlProbe.TabIndex = 1;
-            // 
-            // panel1
-            // 
-            this.panel1.Controls.Add(this.buttonCancel);
-            this.panel1.Controls.Add(this.buttonOkay);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel1.Location = new System.Drawing.Point(0, 0);
-            this.panel1.Margin = new System.Windows.Forms.Padding(2);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(843, 26);
-            this.panel1.TabIndex = 0;
             // 
             // buttonCancel
             // 
-            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonCancel.Location = new System.Drawing.Point(753, 2);
+            this.buttonCancel.Location = new System.Drawing.Point(763, 2);
             this.buttonCancel.Margin = new System.Windows.Forms.Padding(2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(83, 22);
+            this.buttonCancel.Size = new System.Drawing.Size(83, 28);
             this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
@@ -119,21 +83,47 @@
             // buttonOkay
             // 
             this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOkay.Location = new System.Drawing.Point(664, 2);
+            this.buttonOkay.Location = new System.Drawing.Point(676, 2);
             this.buttonOkay.Margin = new System.Windows.Forms.Padding(2);
             this.buttonOkay.Name = "buttonOkay";
-            this.buttonOkay.Size = new System.Drawing.Size(83, 22);
+            this.buttonOkay.Size = new System.Drawing.Size(83, 28);
             this.buttonOkay.TabIndex = 0;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
             this.buttonOkay.Click += new System.EventHandler(this.ButtonClick);
             // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.tabControlProbe, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(854, 554);
+            this.tableLayoutPanel1.TabIndex = 3;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Controls.Add(this.buttonCancel);
+            this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 517);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(848, 34);
+            this.flowLayoutPanel1.TabIndex = 2;
+            // 
             // NeuropixelsV2eDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(843, 530);
-            this.Controls.Add(this.splitContainer1);
+            this.ClientSize = new System.Drawing.Size(854, 578);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -144,11 +134,8 @@
             this.Text = "NeuropixelsV2eDialog";
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
-            this.splitContainer1.Panel1.ResumeLayout(false);
-            this.splitContainer1.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-            this.splitContainer1.ResumeLayout(false);
-            this.panel1.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -157,11 +144,11 @@
         #endregion
 
         private System.Windows.Forms.MenuStrip menuStrip;
-        private System.Windows.Forms.SplitContainer splitContainer1;
-        private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.Button buttonOkay;
         private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
         private System.Windows.Forms.TabControl tabControlProbe;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -79,8 +79,8 @@ namespace OpenEphys.Onix1.Design
         {
             if (!TopLevel)
             {
-                splitContainer1.Panel2Collapsed = true;
-                splitContainer1.Panel2.Hide();
+                tableLayoutPanel1.Controls.Remove(flowLayoutPanel1);
+                tableLayoutPanel1.RowCount = 1;
 
                 menuStrip.Visible = false;
             }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
@@ -29,108 +29,30 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NeuropixelsV2eHeadstageDialog));
-            this.tabControl1 = new System.Windows.Forms.TabControl();
-            this.tabPageNeuropixelsV2e = new System.Windows.Forms.TabPage();
-            this.panelNeuropixelsV2e = new System.Windows.Forms.Panel();
-            this.tabPageBno055 = new System.Windows.Forms.TabPage();
-            this.panelBno055 = new System.Windows.Forms.Panel();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.buttonCancel = new System.Windows.Forms.Button();
             this.buttonOkay = new System.Windows.Forms.Button();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tabControl1.SuspendLayout();
-            this.tabPageNeuropixelsV2e.SuspendLayout();
-            this.tabPageBno055.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-            this.splitContainer1.Panel1.SuspendLayout();
-            this.splitContainer1.Panel2.SuspendLayout();
-            this.splitContainer1.SuspendLayout();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.tabPageBno055 = new System.Windows.Forms.TabPage();
+            this.panelBno055 = new System.Windows.Forms.Panel();
+            this.tabPageNeuropixelsV2e = new System.Windows.Forms.TabPage();
+            this.panelNeuropixelsV2e = new System.Windows.Forms.Panel();
+            this.tabControl1 = new System.Windows.Forms.TabControl();
             this.menuStrip1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
+            this.tabPageBno055.SuspendLayout();
+            this.tabPageNeuropixelsV2e.SuspendLayout();
+            this.tabControl1.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // tabControl1
-            // 
-            this.tabControl1.Controls.Add(this.tabPageNeuropixelsV2e);
-            this.tabControl1.Controls.Add(this.tabPageBno055);
-            this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControl1.Location = new System.Drawing.Point(0, 0);
-            this.tabControl1.Margin = new System.Windows.Forms.Padding(2);
-            this.tabControl1.Name = "tabControl1";
-            this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(863, 468);
-            this.tabControl1.TabIndex = 0;
-            // 
-            // tabPageNeuropixelsV2e
-            // 
-            this.tabPageNeuropixelsV2e.Controls.Add(this.panelNeuropixelsV2e);
-            this.tabPageNeuropixelsV2e.Location = new System.Drawing.Point(4, 22);
-            this.tabPageNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(2);
-            this.tabPageNeuropixelsV2e.Name = "tabPageNeuropixelsV2e";
-            this.tabPageNeuropixelsV2e.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(855, 442);
-            this.tabPageNeuropixelsV2e.TabIndex = 0;
-            this.tabPageNeuropixelsV2e.Text = "NeuropixelsV2e";
-            this.tabPageNeuropixelsV2e.UseVisualStyleBackColor = true;
-            // 
-            // panelNeuropixelsV2e
-            // 
-            this.panelNeuropixelsV2e.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelNeuropixelsV2e.Location = new System.Drawing.Point(2, 2);
-            this.panelNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(2);
-            this.panelNeuropixelsV2e.Name = "panelNeuropixelsV2e";
-            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(851, 438);
-            this.panelNeuropixelsV2e.TabIndex = 0;
-            // 
-            // tabPageBno055
-            // 
-            this.tabPageBno055.Controls.Add(this.panelBno055);
-            this.tabPageBno055.Location = new System.Drawing.Point(4, 22);
-            this.tabPageBno055.Margin = new System.Windows.Forms.Padding(2);
-            this.tabPageBno055.Name = "tabPageBno055";
-            this.tabPageBno055.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPageBno055.Size = new System.Drawing.Size(855, 444);
-            this.tabPageBno055.TabIndex = 1;
-            this.tabPageBno055.Text = "Bno055";
-            this.tabPageBno055.UseVisualStyleBackColor = true;
-            // 
-            // panelBno055
-            // 
-            this.panelBno055.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelBno055.Location = new System.Drawing.Point(2, 2);
-            this.panelBno055.Margin = new System.Windows.Forms.Padding(2);
-            this.panelBno055.Name = "panelBno055";
-            this.panelBno055.Size = new System.Drawing.Size(851, 440);
-            this.panelBno055.TabIndex = 0;
-            // 
-            // splitContainer1
-            // 
-            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer1.IsSplitterFixed = true;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 24);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(2);
-            this.splitContainer1.Name = "splitContainer1";
-            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // splitContainer1.Panel1
-            // 
-            this.splitContainer1.Panel1.Controls.Add(this.tabControl1);
-            // 
-            // splitContainer1.Panel2
-            // 
-            this.splitContainer1.Panel2.Controls.Add(this.buttonCancel);
-            this.splitContainer1.Panel2.Controls.Add(this.buttonOkay);
-            this.splitContainer1.Size = new System.Drawing.Size(863, 503);
-            this.splitContainer1.SplitterDistance = 468;
-            this.splitContainer1.SplitterWidth = 3;
-            this.splitContainer1.TabIndex = 1;
             // 
             // buttonCancel
             // 
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(747, -1);
+            this.buttonCancel.Location = new System.Drawing.Point(747, 2);
             this.buttonCancel.Margin = new System.Windows.Forms.Padding(2);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(108, 26);
@@ -141,7 +63,7 @@
             // buttonOkay
             // 
             this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOkay.Location = new System.Drawing.Point(625, -1);
+            this.buttonOkay.Location = new System.Drawing.Point(635, 2);
             this.buttonOkay.Margin = new System.Windows.Forms.Padding(2);
             this.buttonOkay.Name = "buttonOkay";
             this.buttonOkay.Size = new System.Drawing.Size(108, 26);
@@ -152,28 +74,115 @@
             // 
             // menuStrip1
             // 
+            this.menuStrip1.GripMargin = new System.Windows.Forms.Padding(2, 2, 0, 2);
             this.menuStrip1.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(863, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(863, 31);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(54, 29);
             this.fileToolStripMenuItem.Text = "File";
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.AutoSize = true;
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 31);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(863, 496);
+            this.tableLayoutPanel1.TabIndex = 3;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.AutoSize = true;
+            this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.flowLayoutPanel1.Controls.Add(this.buttonCancel);
+            this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 463);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(857, 30);
+            this.flowLayoutPanel1.TabIndex = 1;
+            // 
+            // tabPageBno055
+            // 
+            this.tabPageBno055.Controls.Add(this.panelBno055);
+            this.tabPageBno055.Location = new System.Drawing.Point(4, 22);
+            this.tabPageBno055.Margin = new System.Windows.Forms.Padding(2);
+            this.tabPageBno055.Name = "tabPageBno055";
+            this.tabPageBno055.Padding = new System.Windows.Forms.Padding(2);
+            this.tabPageBno055.Size = new System.Drawing.Size(689, 293);
+            this.tabPageBno055.TabIndex = 1;
+            this.tabPageBno055.Text = "Bno055";
+            this.tabPageBno055.UseVisualStyleBackColor = true;
+            // 
+            // panelBno055
+            // 
+            this.panelBno055.AutoSize = true;
+            this.panelBno055.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelBno055.Location = new System.Drawing.Point(2, 2);
+            this.panelBno055.Margin = new System.Windows.Forms.Padding(2);
+            this.panelBno055.Name = "panelBno055";
+            this.panelBno055.Size = new System.Drawing.Size(685, 289);
+            this.panelBno055.TabIndex = 0;
+            // 
+            // tabPageNeuropixelsV2e
+            // 
+            this.tabPageNeuropixelsV2e.Controls.Add(this.panelNeuropixelsV2e);
+            this.tabPageNeuropixelsV2e.Location = new System.Drawing.Point(4, 22);
+            this.tabPageNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(2);
+            this.tabPageNeuropixelsV2e.Name = "tabPageNeuropixelsV2e";
+            this.tabPageNeuropixelsV2e.Padding = new System.Windows.Forms.Padding(2);
+            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(851, 430);
+            this.tabPageNeuropixelsV2e.TabIndex = 0;
+            this.tabPageNeuropixelsV2e.Text = "NeuropixelsV2e";
+            this.tabPageNeuropixelsV2e.UseVisualStyleBackColor = true;
+            // 
+            // panelNeuropixelsV2e
+            // 
+            this.panelNeuropixelsV2e.AutoSize = true;
+            this.panelNeuropixelsV2e.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelNeuropixelsV2e.Location = new System.Drawing.Point(2, 2);
+            this.panelNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(2);
+            this.panelNeuropixelsV2e.Name = "panelNeuropixelsV2e";
+            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(847, 426);
+            this.panelNeuropixelsV2e.TabIndex = 0;
+            // 
+            // tabControl1
+            // 
+            this.tabControl1.Controls.Add(this.tabPageNeuropixelsV2e);
+            this.tabControl1.Controls.Add(this.tabPageBno055);
+            this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tabControl1.Location = new System.Drawing.Point(2, 2);
+            this.tabControl1.Margin = new System.Windows.Forms.Padding(2);
+            this.tabControl1.Name = "tabControl1";
+            this.tabControl1.SelectedIndex = 0;
+            this.tabControl1.Size = new System.Drawing.Size(859, 456);
+            this.tabControl1.TabIndex = 0;
             // 
             // NeuropixelsV2eHeadstageDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(863, 527);
-            this.Controls.Add(this.splitContainer1);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip1);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -181,31 +190,32 @@
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "NeuropixelsV2eHeadstageDialog";
             this.Text = "NeuropixelsV2eHeadstageDialog";
-            this.tabControl1.ResumeLayout(false);
-            this.tabPageNeuropixelsV2e.ResumeLayout(false);
-            this.tabPageBno055.ResumeLayout(false);
-            this.splitContainer1.Panel1.ResumeLayout(false);
-            this.splitContainer1.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-            this.splitContainer1.ResumeLayout(false);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.tabPageBno055.ResumeLayout(false);
+            this.tabPageBno055.PerformLayout();
+            this.tabPageNeuropixelsV2e.ResumeLayout(false);
+            this.tabPageNeuropixelsV2e.PerformLayout();
+            this.tabControl1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
         }
 
         #endregion
-
-        private System.Windows.Forms.TabControl tabControl1;
-        private System.Windows.Forms.TabPage tabPageNeuropixelsV2e;
-        private System.Windows.Forms.TabPage tabPageBno055;
-        private System.Windows.Forms.Panel panelNeuropixelsV2e;
-        private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.Button buttonOkay;
-        private System.Windows.Forms.Panel panelBno055;
         private System.Windows.Forms.MenuStrip menuStrip1;
         private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.TabControl tabControl1;
+        private System.Windows.Forms.TabPage tabPageNeuropixelsV2e;
+        private System.Windows.Forms.Panel panelNeuropixelsV2e;
+        private System.Windows.Forms.TabPage tabPageBno055;
+        private System.Windows.Forms.Panel panelBno055;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
@@ -29,16 +29,18 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            System.Windows.Forms.Label label6;
+            System.Windows.Forms.Label label7;
             System.Windows.Forms.Label probeCalibrationFile;
             System.Windows.Forms.Label Reference;
-            System.Windows.Forms.Label label7;
-            System.Windows.Forms.Label label6;
             System.Windows.Forms.Label labelPresets;
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NeuropixelsV2eProbeConfigurationDialog));
             this.menuStrip = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
+            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.buttonEnableContacts = new System.Windows.Forms.Button();
+            this.buttonClearSelections = new System.Windows.Forms.Button();
+            this.buttonResetZoom = new System.Windows.Forms.Button();
             this.panelProbe = new System.Windows.Forms.Panel();
             this.panelTrackBar = new System.Windows.Forms.Panel();
             this.trackBarProbePosition = new System.Windows.Forms.TrackBar();
@@ -47,33 +49,46 @@
             this.textBoxProbeCalibrationFile = new System.Windows.Forms.TextBox();
             this.comboBoxReference = new System.Windows.Forms.ComboBox();
             this.comboBoxChannelPresets = new System.Windows.Forms.ComboBox();
-            this.buttonEnableContacts = new System.Windows.Forms.Button();
-            this.buttonClearSelections = new System.Windows.Forms.Button();
-            this.buttonResetZoom = new System.Windows.Forms.Button();
-            this.panel1 = new System.Windows.Forms.Panel();
             this.buttonCancel = new System.Windows.Forms.Button();
             this.buttonOkay = new System.Windows.Forms.Button();
-            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            label6 = new System.Windows.Forms.Label();
+            label7 = new System.Windows.Forms.Label();
             probeCalibrationFile = new System.Windows.Forms.Label();
             Reference = new System.Windows.Forms.Label();
-            label7 = new System.Windows.Forms.Label();
-            label6 = new System.Windows.Forms.Label();
             labelPresets = new System.Windows.Forms.Label();
             this.menuStrip.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-            this.splitContainer1.Panel1.SuspendLayout();
-            this.splitContainer1.Panel2.SuspendLayout();
-            this.splitContainer1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
-            this.splitContainer2.Panel1.SuspendLayout();
-            this.splitContainer2.Panel2.SuspendLayout();
-            this.splitContainer2.SuspendLayout();
             this.panelProbe.SuspendLayout();
             this.panelTrackBar.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarProbePosition)).BeginInit();
             this.panelChannelOptions.SuspendLayout();
-            this.panel1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // label6
+            // 
+            label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            label6.AutoSize = true;
+            label6.Location = new System.Drawing.Point(0, 440);
+            label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label6.Name = "label6";
+            label6.Size = new System.Drawing.Size(32, 13);
+            label6.TabIndex = 28;
+            label6.Text = "0 mm";
+            // 
+            // label7
+            // 
+            label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            label7.AutoSize = true;
+            label7.Location = new System.Drawing.Point(0, 0);
+            label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label7.Name = "label7";
+            label7.Size = new System.Drawing.Size(38, 13);
+            label7.TabIndex = 29;
+            label7.Text = "10 mm";
+            label7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // probeCalibrationFile
             // 
@@ -95,28 +110,6 @@
             Reference.Size = new System.Drawing.Size(60, 13);
             Reference.TabIndex = 30;
             Reference.Text = "Reference:";
-            // 
-            // label7
-            // 
-            label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            label7.AutoSize = true;
-            label7.Location = new System.Drawing.Point(1, 1);
-            label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            label7.Name = "label7";
-            label7.Size = new System.Drawing.Size(38, 13);
-            label7.TabIndex = 29;
-            label7.Text = "10 mm";
-            // 
-            // label6
-            // 
-            label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            label6.AutoSize = true;
-            label6.Location = new System.Drawing.Point(4, 461);
-            label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            label6.Name = "label6";
-            label6.Size = new System.Drawing.Size(32, 13);
-            label6.TabIndex = 28;
-            label6.Text = "0 mm";
             // 
             // labelPresets
             // 
@@ -146,67 +139,71 @@
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
-            // splitContainer1
+            // buttonEnableContacts
             // 
-            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer1.IsSplitterFixed = true;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 24);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(2);
-            this.splitContainer1.Name = "splitContainer1";
-            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.buttonEnableContacts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonEnableContacts.Location = new System.Drawing.Point(11, 138);
+            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonEnableContacts.Name = "buttonEnableContacts";
+            this.buttonEnableContacts.Size = new System.Drawing.Size(183, 36);
+            this.buttonEnableContacts.TabIndex = 20;
+            this.buttonEnableContacts.Text = "Enable Selected Electrodes";
+            this.toolTip.SetToolTip(this.buttonEnableContacts, "Click and drag to select contacts in the probe view. \r\nPress this button to enabl" +
+        "e the selected contacts.");
+            this.buttonEnableContacts.UseVisualStyleBackColor = true;
+            this.buttonEnableContacts.Click += new System.EventHandler(this.ButtonClick);
             // 
-            // splitContainer1.Panel1
+            // buttonClearSelections
             // 
-            this.splitContainer1.Panel1.Controls.Add(this.splitContainer2);
+            this.buttonClearSelections.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonClearSelections.Location = new System.Drawing.Point(11, 178);
+            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonClearSelections.Name = "buttonClearSelections";
+            this.buttonClearSelections.Size = new System.Drawing.Size(183, 36);
+            this.buttonClearSelections.TabIndex = 19;
+            this.buttonClearSelections.Text = "Clear Electrode Selection";
+            this.toolTip.SetToolTip(this.buttonClearSelections, "Remove selections from contacts in the probe view. Press this button to deselect " +
+        "contacts.\r\nNote that this does not disable contacts, but simply deselects them.");
+            this.buttonClearSelections.UseVisualStyleBackColor = true;
+            this.buttonClearSelections.Click += new System.EventHandler(this.ButtonClick);
             // 
-            // splitContainer1.Panel2
+            // buttonResetZoom
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.panel1);
-            this.splitContainer1.Size = new System.Drawing.Size(834, 509);
-            this.splitContainer1.SplitterDistance = 478;
-            this.splitContainer1.SplitterWidth = 3;
-            this.splitContainer1.TabIndex = 2;
-            // 
-            // splitContainer2
-            // 
-            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer2.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer2.Margin = new System.Windows.Forms.Padding(2);
-            this.splitContainer2.Name = "splitContainer2";
-            // 
-            // splitContainer2.Panel1
-            // 
-            this.splitContainer2.Panel1.Controls.Add(this.panelProbe);
-            // 
-            // splitContainer2.Panel2
-            // 
-            this.splitContainer2.Panel2.Controls.Add(this.panelChannelOptions);
-            this.splitContainer2.Size = new System.Drawing.Size(834, 478);
-            this.splitContainer2.SplitterDistance = 626;
-            this.splitContainer2.SplitterWidth = 3;
-            this.splitContainer2.TabIndex = 1;
+            this.buttonResetZoom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonResetZoom.Location = new System.Drawing.Point(11, 218);
+            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonResetZoom.Name = "buttonResetZoom";
+            this.buttonResetZoom.Size = new System.Drawing.Size(183, 36);
+            this.buttonResetZoom.TabIndex = 4;
+            this.buttonResetZoom.Text = "Reset Zoom";
+            this.toolTip.SetToolTip(this.buttonResetZoom, "Reset the zoom in the probe view so that the probe is zoomed out and centered.\r\nP" +
+        "ress this button to reset the zoom.");
+            this.buttonResetZoom.UseVisualStyleBackColor = true;
+            this.buttonResetZoom.Click += new System.EventHandler(this.ButtonClick);
             // 
             // panelProbe
             // 
+            this.panelProbe.AutoSize = true;
             this.panelProbe.Controls.Add(this.panelTrackBar);
             this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelProbe.Location = new System.Drawing.Point(0, 0);
+            this.panelProbe.Location = new System.Drawing.Point(2, 2);
             this.panelProbe.Margin = new System.Windows.Forms.Padding(2);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(626, 478);
+            this.panelProbe.Size = new System.Drawing.Size(621, 463);
             this.panelProbe.TabIndex = 1;
             // 
             // panelTrackBar
             // 
-            this.panelTrackBar.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.panelTrackBar.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.panelTrackBar.Controls.Add(label6);
             this.panelTrackBar.Controls.Add(label7);
             this.panelTrackBar.Controls.Add(this.trackBarProbePosition);
-            this.panelTrackBar.Location = new System.Drawing.Point(584, 2);
+            this.panelTrackBar.Location = new System.Drawing.Point(581, 6);
             this.panelTrackBar.Name = "panelTrackBar";
-            this.panelTrackBar.Size = new System.Drawing.Size(39, 474);
+            this.panelTrackBar.Size = new System.Drawing.Size(37, 454);
             this.panelTrackBar.TabIndex = 30;
             // 
             // trackBarProbePosition
@@ -214,20 +211,22 @@
             this.trackBarProbePosition.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.trackBarProbePosition.AutoSize = false;
-            this.trackBarProbePosition.Location = new System.Drawing.Point(2, 2);
+            this.trackBarProbePosition.Location = new System.Drawing.Point(-6, 9);
             this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(2);
             this.trackBarProbePosition.Maximum = 100;
             this.trackBarProbePosition.Name = "trackBarProbePosition";
             this.trackBarProbePosition.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBarProbePosition.Size = new System.Drawing.Size(37, 470);
+            this.trackBarProbePosition.Size = new System.Drawing.Size(37, 435);
             this.trackBarProbePosition.TabIndex = 22;
             this.trackBarProbePosition.TickFrequency = 2;
-            this.trackBarProbePosition.TickStyle = System.Windows.Forms.TickStyle.Both;
+            this.trackBarProbePosition.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
             this.trackBarProbePosition.Value = 50;
             this.trackBarProbePosition.Scroll += new System.EventHandler(this.TrackBarScroll);
             // 
             // panelChannelOptions
             // 
+            this.panelChannelOptions.AutoSize = true;
+            this.panelChannelOptions.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.panelChannelOptions.BackColor = System.Drawing.SystemColors.ControlLightLight;
             this.panelChannelOptions.Controls.Add(this.buttonChooseCalibrationFile);
             this.panelChannelOptions.Controls.Add(this.textBoxProbeCalibrationFile);
@@ -240,10 +239,10 @@
             this.panelChannelOptions.Controls.Add(this.buttonClearSelections);
             this.panelChannelOptions.Controls.Add(this.buttonResetZoom);
             this.panelChannelOptions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelChannelOptions.Location = new System.Drawing.Point(0, 0);
+            this.panelChannelOptions.Location = new System.Drawing.Point(627, 2);
             this.panelChannelOptions.Margin = new System.Windows.Forms.Padding(2);
             this.panelChannelOptions.Name = "panelChannelOptions";
-            this.panelChannelOptions.Size = new System.Drawing.Size(205, 478);
+            this.panelChannelOptions.Size = new System.Drawing.Size(205, 463);
             this.panelChannelOptions.TabIndex = 1;
             // 
             // buttonChooseCalibrationFile
@@ -293,70 +292,15 @@
             this.comboBoxChannelPresets.Size = new System.Drawing.Size(116, 21);
             this.comboBoxChannelPresets.TabIndex = 24;
             // 
-            // buttonEnableContacts
-            // 
-            this.buttonEnableContacts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonEnableContacts.Location = new System.Drawing.Point(11, 138);
-            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(2);
-            this.buttonEnableContacts.Name = "buttonEnableContacts";
-            this.buttonEnableContacts.Size = new System.Drawing.Size(183, 36);
-            this.buttonEnableContacts.TabIndex = 20;
-            this.buttonEnableContacts.Text = "Enable Selected Electrodes";
-            this.toolTip.SetToolTip(this.buttonEnableContacts, "Click and drag to select contacts in the probe view. \r\nPress this button to enabl" +
-        "e the selected contacts.");
-            this.buttonEnableContacts.UseVisualStyleBackColor = true;
-            this.buttonEnableContacts.Click += new System.EventHandler(this.ButtonClick);
-            // 
-            // buttonClearSelections
-            // 
-            this.buttonClearSelections.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClearSelections.Location = new System.Drawing.Point(11, 178);
-            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(2);
-            this.buttonClearSelections.Name = "buttonClearSelections";
-            this.buttonClearSelections.Size = new System.Drawing.Size(183, 36);
-            this.buttonClearSelections.TabIndex = 19;
-            this.buttonClearSelections.Text = "Clear Electrode Selection";
-            this.toolTip.SetToolTip(this.buttonClearSelections, "Remove selections from contacts in the probe view. Press this button to deselect " +
-        "contacts.\r\nNote that this does not disable contacts, but simply deselects them.");
-            this.buttonClearSelections.UseVisualStyleBackColor = true;
-            this.buttonClearSelections.Click += new System.EventHandler(this.ButtonClick);
-            // 
-            // buttonResetZoom
-            // 
-            this.buttonResetZoom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonResetZoom.Location = new System.Drawing.Point(11, 218);
-            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(2);
-            this.buttonResetZoom.Name = "buttonResetZoom";
-            this.buttonResetZoom.Size = new System.Drawing.Size(183, 36);
-            this.buttonResetZoom.TabIndex = 4;
-            this.buttonResetZoom.Text = "Reset Zoom";
-            this.toolTip.SetToolTip(this.buttonResetZoom, "Reset the zoom in the probe view so that the probe is zoomed out and centered.\r\nP" +
-        "ress this button to reset the zoom.");
-            this.buttonResetZoom.UseVisualStyleBackColor = true;
-            this.buttonResetZoom.Click += new System.EventHandler(this.ButtonClick);
-            // 
-            // panel1
-            // 
-            this.panel1.Controls.Add(this.buttonCancel);
-            this.panel1.Controls.Add(this.buttonOkay);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel1.Location = new System.Drawing.Point(0, 0);
-            this.panel1.Margin = new System.Windows.Forms.Padding(2);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(834, 28);
-            this.panel1.TabIndex = 0;
-            // 
             // buttonCancel
             // 
-            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(744, 2);
+            this.buttonCancel.Location = new System.Drawing.Point(726, 2);
             this.buttonCancel.Margin = new System.Windows.Forms.Padding(2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(83, 22);
+            this.buttonCancel.Size = new System.Drawing.Size(100, 30);
             this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
@@ -364,22 +308,54 @@
             // 
             // buttonOkay
             // 
-            this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOkay.Location = new System.Drawing.Point(655, 2);
+            this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonOkay.Location = new System.Drawing.Point(622, 2);
             this.buttonOkay.Margin = new System.Windows.Forms.Padding(2);
             this.buttonOkay.Name = "buttonOkay";
-            this.buttonOkay.Size = new System.Drawing.Size(83, 22);
+            this.buttonOkay.Size = new System.Drawing.Size(100, 30);
             this.buttonOkay.TabIndex = 0;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
             this.buttonOkay.Click += new System.EventHandler(this.ButtonClick);
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.AutoSize = true;
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 75F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tableLayoutPanel1.Controls.Add(this.panelChannelOptions, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.panelProbe, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(834, 509);
+            this.tableLayoutPanel1.TabIndex = 3;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel1, 2);
+            this.flowLayoutPanel1.Controls.Add(this.buttonCancel);
+            this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 470);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(828, 36);
+            this.flowLayoutPanel1.TabIndex = 2;
             // 
             // NeuropixelsV2eProbeConfigurationDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(834, 533);
-            this.Controls.Add(this.splitContainer1);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -390,21 +366,15 @@
             this.Text = "NeuropixelsV2eProbeConfigurationDialog";
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
-            this.splitContainer1.Panel1.ResumeLayout(false);
-            this.splitContainer1.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-            this.splitContainer1.ResumeLayout(false);
-            this.splitContainer2.Panel1.ResumeLayout(false);
-            this.splitContainer2.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
-            this.splitContainer2.ResumeLayout(false);
             this.panelProbe.ResumeLayout(false);
             this.panelTrackBar.ResumeLayout(false);
             this.panelTrackBar.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarProbePosition)).EndInit();
             this.panelChannelOptions.ResumeLayout(false);
             this.panelChannelOptions.PerformLayout();
-            this.panel1.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -413,23 +383,22 @@
         #endregion
 
         private System.Windows.Forms.MenuStrip menuStrip;
-        private System.Windows.Forms.SplitContainer splitContainer1;
-        private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Button buttonCancel;
-        private System.Windows.Forms.Button buttonOkay;
         private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
-        private System.Windows.Forms.SplitContainer splitContainer2;
+        private System.Windows.Forms.ToolTip toolTip;
         private System.Windows.Forms.Panel panelProbe;
+        private System.Windows.Forms.Panel panelTrackBar;
+        private System.Windows.Forms.TrackBar trackBarProbePosition;
         private System.Windows.Forms.Panel panelChannelOptions;
+        private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.Button buttonChooseCalibrationFile;
+        private System.Windows.Forms.Button buttonOkay;
         internal System.Windows.Forms.TextBox textBoxProbeCalibrationFile;
         private System.Windows.Forms.ComboBox comboBoxReference;
         private System.Windows.Forms.ComboBox comboBoxChannelPresets;
-        private System.Windows.Forms.TrackBar trackBarProbePosition;
         private System.Windows.Forms.Button buttonEnableContacts;
         private System.Windows.Forms.Button buttonClearSelections;
         private System.Windows.Forms.Button buttonResetZoom;
-        private System.Windows.Forms.ToolTip toolTip;
-        private System.Windows.Forms.Panel panelTrackBar;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -96,8 +96,8 @@ namespace OpenEphys.Onix1.Design
         {
             if (!TopLevel)
             {
-                splitContainer1.Panel2Collapsed = true;
-                splitContainer1.Panel2.Hide();
+                tableLayoutPanel1.Controls.Remove(flowLayoutPanel1);
+                tableLayoutPanel1.RowCount = 1;
 
                 menuStrip.Visible = false;
             }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.resx
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.resx
@@ -117,16 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="probeCalibrationFile.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
-  <metadata name="Reference.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="label6.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
   <metadata name="label7.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="label6.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="probeCalibrationFile.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <metadata name="Reference.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
   <metadata name="labelPresets.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
+++ b/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
@@ -8,6 +8,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <Platforms>x64</Platforms>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+    <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
At scale values different from 100% on Windows 11 machines, the `NeuropixelsV2e` dialogs would not scale correctly, leading to hidden controls and making the GUI effectively useless. 

In this PR, all `NeuropixelsV2e` dialogs were updated to use `FlowLayoutPanel` and `TableLayoutPanel` instead of `SplitterPanel`, as the two former panels handle resizing at different scale values more robustly than the latter. 

One consequence of switching to these panels is that they are no longer movable from the user perspective; that is, all panel sizes are locked to their relative size. To view the full filepath for a configuration file, sometimes when maximizing the window it will show the entire path; if that is not enough, the filepath is inside of a textbox that can be selected and stepped through using the arrow keys to view the path.

Fixes #241 