### PR TITLE
Modify dialog title bars to be more readable

### DIFF
--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.Designer.cs
@@ -65,7 +65,7 @@
             this.splitContainer1.Panel2.Controls.Add(this.buttonCancel);
             this.splitContainer1.Panel2.Controls.Add(this.buttonOK);
             this.splitContainer1.Size = new System.Drawing.Size(457, 442);
-            this.splitContainer1.SplitterDistance = 404;
+            this.splitContainer1.SplitterDistance = 405;
             this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 0;
             // 
@@ -83,7 +83,7 @@
             this.zedGraphChannels.ScrollMinX = 0D;
             this.zedGraphChannels.ScrollMinY = 0D;
             this.zedGraphChannels.ScrollMinY2 = 0D;
-            this.zedGraphChannels.Size = new System.Drawing.Size(457, 404);
+            this.zedGraphChannels.Size = new System.Drawing.Size(457, 405);
             this.zedGraphChannels.TabIndex = 4;
             this.zedGraphChannels.UseExtendedPrintDialog = true;
             this.zedGraphChannels.ZoomEvent += new ZedGraph.ZedGraphControl.ZoomEventHandler(this.ZoomEvent);
@@ -166,7 +166,7 @@
             this.MainMenuStrip = this.menuStrip;
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "ChannelConfigurationDialog";
-            this.Text = "ChannelConfigurationDialog";
+            this.Text = "Channel Configuration";
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/GenericDeviceDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/GenericDeviceDialog.Designer.cs
@@ -45,7 +45,7 @@
             this.propertyGrid.Location = new System.Drawing.Point(0, 0);
             this.propertyGrid.Margin = new System.Windows.Forms.Padding(2);
             this.propertyGrid.Name = "propertyGrid";
-            this.propertyGrid.Size = new System.Drawing.Size(252, 348);
+            this.propertyGrid.Size = new System.Drawing.Size(252, 349);
             this.propertyGrid.TabIndex = 0;
             // 
             // splitContainer1
@@ -67,7 +67,7 @@
             this.splitContainer1.Panel2.Controls.Add(this.buttonCancel);
             this.splitContainer1.Panel2.Controls.Add(this.buttonOK);
             this.splitContainer1.Size = new System.Drawing.Size(252, 386);
-            this.splitContainer1.SplitterDistance = 348;
+            this.splitContainer1.SplitterDistance = 349;
             this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 1;
             // 
@@ -108,7 +108,7 @@
             this.Name = "GenericDeviceDialog";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "GenericDeviceDialog";
+            this.Text = "Generic Device Configuration";
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eDialog.Designer.cs
@@ -475,7 +475,7 @@
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "NeuropixelsV1eDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "NeuropixelsV1eDialog";
+            this.Text = "NeuropixelsV1e Configuration";
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
             this.panelProbe.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.Designer.cs
@@ -88,7 +88,7 @@
             this.tabPageBno055.Margin = new System.Windows.Forms.Padding(2);
             this.tabPageBno055.Name = "tabPageBno055";
             this.tabPageBno055.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPageBno055.Size = new System.Drawing.Size(1026, 578);
+            this.tabPageBno055.Size = new System.Drawing.Size(1005, 559);
             this.tabPageBno055.TabIndex = 1;
             this.tabPageBno055.Text = "Bno055";
             this.tabPageBno055.UseVisualStyleBackColor = true;
@@ -99,7 +99,7 @@
             this.panelBno055.Location = new System.Drawing.Point(2, 2);
             this.panelBno055.Margin = new System.Windows.Forms.Padding(2);
             this.panelBno055.Name = "panelBno055";
-            this.panelBno055.Size = new System.Drawing.Size(1022, 574);
+            this.panelBno055.Size = new System.Drawing.Size(1001, 555);
             this.panelBno055.TabIndex = 0;
             // 
             // buttonCancel
@@ -181,7 +181,7 @@
             this.MainMenuStrip = this.menuStrip1;
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "NeuropixelsV1eHeadstageDialog";
-            this.Text = "NeuropixelsV1eHeadstageDialog";
+            this.Text = "NeuropixelsV1e Headstage Configuration";
             this.tabControl1.ResumeLayout(false);
             this.tabPageNeuropixelsV1e.ResumeLayout(false);
             this.tabPageBno055.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
@@ -131,7 +131,7 @@
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "NeuropixelsV2eDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "NeuropixelsV2eDialog";
+            this.Text = "NeuropixelsV2e Configuration";
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
@@ -34,18 +34,18 @@
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.tabPageBno055 = new System.Windows.Forms.TabPage();
-            this.panelBno055 = new System.Windows.Forms.Panel();
+            this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPageNeuropixelsV2e = new System.Windows.Forms.TabPage();
             this.panelNeuropixelsV2e = new System.Windows.Forms.Panel();
-            this.tabControl1 = new System.Windows.Forms.TabControl();
+            this.tabPageBno055 = new System.Windows.Forms.TabPage();
+            this.panelBno055 = new System.Windows.Forms.Panel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.menuStrip1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
-            this.flowLayoutPanel1.SuspendLayout();
-            this.tabPageBno055.SuspendLayout();
-            this.tabPageNeuropixelsV2e.SuspendLayout();
             this.tabControl1.SuspendLayout();
+            this.tabPageNeuropixelsV2e.SuspendLayout();
+            this.tabPageBno055.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // buttonCancel
@@ -74,21 +74,20 @@
             // 
             // menuStrip1
             // 
-            this.menuStrip1.GripMargin = new System.Windows.Forms.Padding(2, 2, 0, 2);
             this.menuStrip1.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(863, 31);
+            this.menuStrip1.Size = new System.Drawing.Size(863, 24);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(54, 29);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -100,48 +99,25 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 31);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(863, 496);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(863, 503);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
-            // flowLayoutPanel1
+            // tabControl1
             // 
-            this.flowLayoutPanel1.AutoSize = true;
-            this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.flowLayoutPanel1.Controls.Add(this.buttonCancel);
-            this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
-            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 463);
-            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(857, 30);
-            this.flowLayoutPanel1.TabIndex = 1;
-            // 
-            // tabPageBno055
-            // 
-            this.tabPageBno055.Controls.Add(this.panelBno055);
-            this.tabPageBno055.Location = new System.Drawing.Point(4, 22);
-            this.tabPageBno055.Margin = new System.Windows.Forms.Padding(2);
-            this.tabPageBno055.Name = "tabPageBno055";
-            this.tabPageBno055.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPageBno055.Size = new System.Drawing.Size(689, 293);
-            this.tabPageBno055.TabIndex = 1;
-            this.tabPageBno055.Text = "Bno055";
-            this.tabPageBno055.UseVisualStyleBackColor = true;
-            // 
-            // panelBno055
-            // 
-            this.panelBno055.AutoSize = true;
-            this.panelBno055.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelBno055.Location = new System.Drawing.Point(2, 2);
-            this.panelBno055.Margin = new System.Windows.Forms.Padding(2);
-            this.panelBno055.Name = "panelBno055";
-            this.panelBno055.Size = new System.Drawing.Size(685, 289);
-            this.panelBno055.TabIndex = 0;
+            this.tabControl1.Controls.Add(this.tabPageNeuropixelsV2e);
+            this.tabControl1.Controls.Add(this.tabPageBno055);
+            this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tabControl1.Location = new System.Drawing.Point(2, 2);
+            this.tabControl1.Margin = new System.Windows.Forms.Padding(2);
+            this.tabControl1.Name = "tabControl1";
+            this.tabControl1.SelectedIndex = 0;
+            this.tabControl1.Size = new System.Drawing.Size(859, 463);
+            this.tabControl1.TabIndex = 0;
             // 
             // tabPageNeuropixelsV2e
             // 
@@ -150,7 +126,7 @@
             this.tabPageNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(2);
             this.tabPageNeuropixelsV2e.Name = "tabPageNeuropixelsV2e";
             this.tabPageNeuropixelsV2e.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(851, 430);
+            this.tabPageNeuropixelsV2e.Size = new System.Drawing.Size(851, 437);
             this.tabPageNeuropixelsV2e.TabIndex = 0;
             this.tabPageNeuropixelsV2e.Text = "NeuropixelsV2e";
             this.tabPageNeuropixelsV2e.UseVisualStyleBackColor = true;
@@ -162,20 +138,43 @@
             this.panelNeuropixelsV2e.Location = new System.Drawing.Point(2, 2);
             this.panelNeuropixelsV2e.Margin = new System.Windows.Forms.Padding(2);
             this.panelNeuropixelsV2e.Name = "panelNeuropixelsV2e";
-            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(847, 426);
+            this.panelNeuropixelsV2e.Size = new System.Drawing.Size(847, 433);
             this.panelNeuropixelsV2e.TabIndex = 0;
             // 
-            // tabControl1
+            // tabPageBno055
             // 
-            this.tabControl1.Controls.Add(this.tabPageNeuropixelsV2e);
-            this.tabControl1.Controls.Add(this.tabPageBno055);
-            this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControl1.Location = new System.Drawing.Point(2, 2);
-            this.tabControl1.Margin = new System.Windows.Forms.Padding(2);
-            this.tabControl1.Name = "tabControl1";
-            this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(859, 456);
-            this.tabControl1.TabIndex = 0;
+            this.tabPageBno055.Controls.Add(this.panelBno055);
+            this.tabPageBno055.Location = new System.Drawing.Point(4, 22);
+            this.tabPageBno055.Margin = new System.Windows.Forms.Padding(2);
+            this.tabPageBno055.Name = "tabPageBno055";
+            this.tabPageBno055.Padding = new System.Windows.Forms.Padding(2);
+            this.tabPageBno055.Size = new System.Drawing.Size(851, 430);
+            this.tabPageBno055.TabIndex = 1;
+            this.tabPageBno055.Text = "Bno055";
+            this.tabPageBno055.UseVisualStyleBackColor = true;
+            // 
+            // panelBno055
+            // 
+            this.panelBno055.AutoSize = true;
+            this.panelBno055.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelBno055.Location = new System.Drawing.Point(2, 2);
+            this.panelBno055.Margin = new System.Windows.Forms.Padding(2);
+            this.panelBno055.Name = "panelBno055";
+            this.panelBno055.Size = new System.Drawing.Size(847, 426);
+            this.panelBno055.TabIndex = 0;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.AutoSize = true;
+            this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.flowLayoutPanel1.Controls.Add(this.buttonCancel);
+            this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 470);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(857, 30);
+            this.flowLayoutPanel1.TabIndex = 1;
             // 
             // NeuropixelsV2eHeadstageDialog
             // 
@@ -189,17 +188,17 @@
             this.MainMenuStrip = this.menuStrip1;
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "NeuropixelsV2eHeadstageDialog";
-            this.Text = "NeuropixelsV2eHeadstageDialog";
+            this.Text = "NeuropixelsV2e Headstage Configuration";
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.tabPageBno055.ResumeLayout(false);
-            this.tabPageBno055.PerformLayout();
+            this.tabControl1.ResumeLayout(false);
             this.tabPageNeuropixelsV2e.ResumeLayout(false);
             this.tabPageNeuropixelsV2e.PerformLayout();
-            this.tabControl1.ResumeLayout(false);
+            this.tabPageBno055.ResumeLayout(false);
+            this.tabPageBno055.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
@@ -41,11 +41,11 @@
             this.buttonEnableContacts = new System.Windows.Forms.Button();
             this.buttonClearSelections = new System.Windows.Forms.Button();
             this.buttonResetZoom = new System.Windows.Forms.Button();
+            this.buttonChooseCalibrationFile = new System.Windows.Forms.Button();
             this.panelProbe = new System.Windows.Forms.Panel();
             this.panelTrackBar = new System.Windows.Forms.Panel();
             this.trackBarProbePosition = new System.Windows.Forms.TrackBar();
             this.panelChannelOptions = new System.Windows.Forms.Panel();
-            this.buttonChooseCalibrationFile = new System.Windows.Forms.Button();
             this.textBoxProbeCalibrationFile = new System.Windows.Forms.TextBox();
             this.comboBoxReference = new System.Windows.Forms.ComboBox();
             this.comboBoxChannelPresets = new System.Windows.Forms.ComboBox();
@@ -146,11 +146,11 @@
             this.buttonEnableContacts.Location = new System.Drawing.Point(11, 138);
             this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(2);
             this.buttonEnableContacts.Name = "buttonEnableContacts";
-            this.buttonEnableContacts.Size = new System.Drawing.Size(183, 36);
+            this.buttonEnableContacts.Size = new System.Drawing.Size(182, 36);
             this.buttonEnableContacts.TabIndex = 20;
             this.buttonEnableContacts.Text = "Enable Selected Electrodes";
-            this.toolTip.SetToolTip(this.buttonEnableContacts, "Click and drag to select contacts in the probe view. \r\nPress this button to enabl" +
-        "e the selected contacts.");
+            this.toolTip.SetToolTip(this.buttonEnableContacts, "Click and drag to select electrodes in the probe view. \r\nPress this button to ena" +
+        "ble the selected electrodes. \r\nNot all electrode combinations are possible.");
             this.buttonEnableContacts.UseVisualStyleBackColor = true;
             this.buttonEnableContacts.Click += new System.EventHandler(this.ButtonClick);
             // 
@@ -161,11 +161,11 @@
             this.buttonClearSelections.Location = new System.Drawing.Point(11, 178);
             this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(2);
             this.buttonClearSelections.Name = "buttonClearSelections";
-            this.buttonClearSelections.Size = new System.Drawing.Size(183, 36);
+            this.buttonClearSelections.Size = new System.Drawing.Size(182, 36);
             this.buttonClearSelections.TabIndex = 19;
             this.buttonClearSelections.Text = "Clear Electrode Selection";
-            this.toolTip.SetToolTip(this.buttonClearSelections, "Remove selections from contacts in the probe view. Press this button to deselect " +
-        "contacts.\r\nNote that this does not disable contacts, but simply deselects them.");
+            this.toolTip.SetToolTip(this.buttonClearSelections, "Deselect all electrodes in the probe view. \r\nNote that this does not disable elec" +
+        "trodes, but simply deselects them.");
             this.buttonClearSelections.UseVisualStyleBackColor = true;
             this.buttonClearSelections.Click += new System.EventHandler(this.ButtonClick);
             // 
@@ -176,13 +176,25 @@
             this.buttonResetZoom.Location = new System.Drawing.Point(11, 218);
             this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(2);
             this.buttonResetZoom.Name = "buttonResetZoom";
-            this.buttonResetZoom.Size = new System.Drawing.Size(183, 36);
+            this.buttonResetZoom.Size = new System.Drawing.Size(182, 36);
             this.buttonResetZoom.TabIndex = 4;
             this.buttonResetZoom.Text = "Reset Zoom";
-            this.toolTip.SetToolTip(this.buttonResetZoom, "Reset the zoom in the probe view so that the probe is zoomed out and centered.\r\nP" +
-        "ress this button to reset the zoom.");
+            this.toolTip.SetToolTip(this.buttonResetZoom, "Reset the zoom in the probe view so that the probe is zoomed out and centered.");
             this.buttonResetZoom.UseVisualStyleBackColor = true;
             this.buttonResetZoom.Click += new System.EventHandler(this.ButtonClick);
+            // 
+            // buttonChooseCalibrationFile
+            // 
+            this.buttonChooseCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonChooseCalibrationFile.Location = new System.Drawing.Point(169, 24);
+            this.buttonChooseCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonChooseCalibrationFile.Name = "buttonChooseCalibrationFile";
+            this.buttonChooseCalibrationFile.Size = new System.Drawing.Size(28, 20);
+            this.buttonChooseCalibrationFile.TabIndex = 34;
+            this.buttonChooseCalibrationFile.Text = "...";
+            this.toolTip.SetToolTip(this.buttonChooseCalibrationFile, "Browse for a gain calibration file.");
+            this.buttonChooseCalibrationFile.UseVisualStyleBackColor = true;
+            this.buttonChooseCalibrationFile.Click += new System.EventHandler(this.ButtonClick);
             // 
             // panelProbe
             // 
@@ -245,19 +257,6 @@
             this.panelChannelOptions.Size = new System.Drawing.Size(205, 463);
             this.panelChannelOptions.TabIndex = 1;
             // 
-            // buttonChooseCalibrationFile
-            // 
-            this.buttonChooseCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseCalibrationFile.Location = new System.Drawing.Point(169, 24);
-            this.buttonChooseCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
-            this.buttonChooseCalibrationFile.Name = "buttonChooseCalibrationFile";
-            this.buttonChooseCalibrationFile.Size = new System.Drawing.Size(28, 20);
-            this.buttonChooseCalibrationFile.TabIndex = 34;
-            this.buttonChooseCalibrationFile.Text = "...";
-            this.toolTip.SetToolTip(this.buttonChooseCalibrationFile, "Browse for a gain calibration file.");
-            this.buttonChooseCalibrationFile.UseVisualStyleBackColor = true;
-            this.buttonChooseCalibrationFile.Click += new System.EventHandler(this.ButtonClick);
-            // 
             // textBoxProbeCalibrationFile
             // 
             this.textBoxProbeCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
@@ -292,50 +291,6 @@
             this.comboBoxChannelPresets.Name = "comboBoxChannelPresets";
             this.comboBoxChannelPresets.Size = new System.Drawing.Size(115, 21);
             this.comboBoxChannelPresets.TabIndex = 24;
-            // 
-            // buttonEnableContacts
-            // 
-            this.buttonEnableContacts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonEnableContacts.Location = new System.Drawing.Point(11, 138);
-            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(2);
-            this.buttonEnableContacts.Name = "buttonEnableContacts";
-            this.buttonEnableContacts.Size = new System.Drawing.Size(182, 36);
-            this.buttonEnableContacts.TabIndex = 20;
-            this.buttonEnableContacts.Text = "Enable Selected Electrodes";
-            this.toolTip.SetToolTip(this.buttonEnableContacts, "Click and drag to select electrodes in the probe view. \r\nPress this button to ena" +
-        "ble the selected electrodes. \r\nNot all electrode combinations are possible.");
-            this.buttonEnableContacts.UseVisualStyleBackColor = true;
-            this.buttonEnableContacts.Click += new System.EventHandler(this.ButtonClick);
-            // 
-            // buttonClearSelections
-            // 
-            this.buttonClearSelections.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClearSelections.Location = new System.Drawing.Point(11, 178);
-            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(2);
-            this.buttonClearSelections.Name = "buttonClearSelections";
-            this.buttonClearSelections.Size = new System.Drawing.Size(182, 36);
-            this.buttonClearSelections.TabIndex = 19;
-            this.buttonClearSelections.Text = "Clear Electrode Selection";
-            this.toolTip.SetToolTip(this.buttonClearSelections, "Deselect all electrodes in the probe view. \r\nNote that this does not disable elec" +
-        "trodes, but simply deselects them.");
-            this.buttonClearSelections.UseVisualStyleBackColor = true;
-            this.buttonClearSelections.Click += new System.EventHandler(this.ButtonClick);
-            // 
-            // buttonResetZoom
-            // 
-            this.buttonResetZoom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonResetZoom.Location = new System.Drawing.Point(11, 218);
-            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(2);
-            this.buttonResetZoom.Name = "buttonResetZoom";
-            this.buttonResetZoom.Size = new System.Drawing.Size(182, 36);
-            this.buttonResetZoom.TabIndex = 4;
-            this.buttonResetZoom.Text = "Reset Zoom";
-            this.toolTip.SetToolTip(this.buttonResetZoom, "Reset the zoom in the probe view so that the probe is zoomed out and centered.");
-            this.buttonResetZoom.UseVisualStyleBackColor = true;
-            this.buttonResetZoom.Click += new System.EventHandler(this.ButtonClick);
             // 
             // buttonCancel
             // 
@@ -408,7 +363,7 @@
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "NeuropixelsV2eProbeConfigurationDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "NeuropixelsV2eProbeConfigurationDialog";
+            this.Text = "NeuropixelsV2e Probe Configuration";
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
             this.panelProbe.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -90,6 +90,8 @@ namespace OpenEphys.Onix1.Design
             comboBoxChannelPresets.DataSource = Enum.GetValues(typeof(ChannelPreset));
             comboBoxChannelPresets.SelectedIndexChanged += SelectedIndexChanged;
             CheckForExistingChannelPreset();
+
+            Text += ": " + ProbeConfiguration.Probe.ToString();
         }
 
         private void FormShown(object sender, EventArgs e)


### PR DESCRIPTION
Initially the title bar for each dialog was simply a reflection of the type (`NeuropixelsV2eHeadstageDialog`). To make the title bars more user-friendly, these strings were modified to be more readable (`NeuropixelsV2e Headstage Configuration`).

Closes #242.