### PR TITLE
Restrict possible driver values

### DIFF
--- a/OpenEphys.Onix1/ContextDriverConverter.cs
+++ b/OpenEphys.Onix1/ContextDriverConverter.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+
+namespace OpenEphys.Onix1
+{
+    internal class ContextDriverConverter : StringConverter
+    {
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            return new StandardValuesCollection(new[]
+            {
+                "riffa"
+            });
+        }
+    }
+}

--- a/OpenEphys.Onix1/CreateContext.cs
+++ b/OpenEphys.Onix1/CreateContext.cs
@@ -19,6 +19,7 @@ namespace OpenEphys.Onix1
         /// </summary>
         [Description("Specifies the device driver used to communicate with hardware.")]
         [Category(DeviceFactory.ConfigurationCategory)]
+        [TypeConverter(typeof(ContextDriverConverter))]
         public string Driver { get; set; } = ContextTask.DefaultDriver;
 
         /// <summary>


### PR DESCRIPTION
In the `CreateContext` node users could previously type in a string to specify a specific device driver. However, in this PR we restrict the possible values to a drop-down menu that consists of exactly one item: `riffa`.

Fixes #178 