### PR TITLE
Add package types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,10 +13,11 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>
+    <PackageType>Dependency;BonsaiLibrary</PackageType>
   </PropertyGroup>
 
   <Import Project="build/Version.props" />


### PR DESCRIPTION
As Bonsai migrates from MyGet to NuGet, there is a growing need to differentiate Bonsai-specific packages from the rest of them. One way to accomplish this is using `PackageTypes` to define packages as a specific type, in our case a `BonsaiLibrary`.

Fixes #245 