### PR TITLE
Only skip check-semver during releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
   check-semver:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'release'
     steps:
       - name: Checkout current version
         uses: actions/checkout@v4


### PR DESCRIPTION
Changing the logic slightly for actions, now the semantic version is checked after pushing to main, such as a merged PR. Now, the only time the `check-semver` job is skipped is during a release, since the release version and the current version will always be the same at that point.