### PR TITLE
Add NeuropixelsV2eBeta GUIs

### DIFF
--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -17,18 +17,26 @@ namespace OpenEphys.Onix1.Design
         /// Public <see cref="ConfigureNeuropixelsV2e"/> object that is manipulated by
         /// <see cref="NeuropixelsV2eDialog"/>.
         /// </summary>
-        public ConfigureNeuropixelsV2e ConfigureNode { get; set; }
+        public IConfigureNeuropixelsV2 ConfigureNode { get; set; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="NeuropixelsV2eDialog"/>.
         /// </summary>
         /// <param name="configureNode">A <see cref="ConfigureNeuropixelsV2e"/> object holding the current configuration settings.</param>
-        public NeuropixelsV2eDialog(ConfigureNeuropixelsV2e configureNode)
+        public NeuropixelsV2eDialog(IConfigureNeuropixelsV2 configureNode)
         {
             InitializeComponent();
             Shown += FormShown;
 
-            ConfigureNode = new(configureNode);
+            if (configureNode is ConfigureNeuropixelsV2eBeta configureV2eBeta)
+            {
+                ConfigureNode = new ConfigureNeuropixelsV2eBeta(configureV2eBeta);
+                Text = Text.Replace("NeuropixelsV2e ", "NeuropixelsV2eBeta ");
+            }
+            else if (configureNode is ConfigureNeuropixelsV2e configureV2e)
+            {
+                ConfigureNode = new ConfigureNeuropixelsV2e(configureV2e);
+            }
 
             ProbeConfigurations = new List<NeuropixelsV2eProbeConfigurationDialog>
             {

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eEditor.cs
@@ -16,7 +16,7 @@ namespace OpenEphys.Onix1.Design
             if (provider != null)
             {
                 var editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
-                if (editorState != null && !editorState.WorkflowRunning && component is ConfigureNeuropixelsV2e configureNeuropixelsV2e)
+                if (editorState != null && !editorState.WorkflowRunning && component is IConfigureNeuropixelsV2 configureNeuropixelsV2e)
                 {
                     using var editorDialog = new NeuropixelsV2eDialog(configureNeuropixelsV2e);
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
@@ -22,7 +22,7 @@ namespace OpenEphys.Onix1.Design
         /// </summary>
         /// <param name="configureNeuropixelsV2e">Configuration settings for a <see cref="ConfigureNeuropixelsV2e"/>.</param>
         /// <param name="configureBno055">Configuration settings for a <see cref="ConfigureNeuropixelsV2eBno055"/>.</param>
-        public NeuropixelsV2eHeadstageDialog(ConfigureNeuropixelsV2e configureNeuropixelsV2e, ConfigureNeuropixelsV2eBno055 configureBno055)
+        public NeuropixelsV2eHeadstageDialog(IConfigureNeuropixelsV2 configureNeuropixelsV2e, ConfigureNeuropixelsV2eBno055 configureBno055)
         {
             InitializeComponent();
 
@@ -35,7 +35,18 @@ namespace OpenEphys.Onix1.Design
             };
 
             panelNeuropixelsV2e.Controls.Add(DialogNeuropixelsV2e);
-            this.AddMenuItemsFromDialogToFileOption(DialogNeuropixelsV2e, "NeuropixelsV2e");
+
+            if (configureNeuropixelsV2e is ConfigureNeuropixelsV2e)
+            {
+                this.AddMenuItemsFromDialogToFileOption(DialogNeuropixelsV2e, "NeuropixelsV2e");
+            }
+            else if (configureNeuropixelsV2e is ConfigureNeuropixelsV2eBeta)
+            {
+                this.AddMenuItemsFromDialogToFileOption(DialogNeuropixelsV2e, "NeuropixelsV2eBeta");
+                Text = Text.Replace("NeuropixelsV2e ", "NeuropixelsV2eBeta ");
+                tabPageNeuropixelsV2e.Text = "NeuropixelsV2eBeta";
+            }
+
             DialogNeuropixelsV2e.Show();
 
             DialogBno055 = new(configureBno055)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageEditor.cs
@@ -16,19 +16,37 @@ namespace OpenEphys.Onix1.Design
             if (provider != null)
             {
                 var editorState = (IWorkflowEditorState)provider.GetService(typeof(IWorkflowEditorState));
-                if (editorState != null && !editorState.WorkflowRunning && component is ConfigureNeuropixelsV2eHeadstage configureHeadstage)
+
+                if (editorState != null && !editorState.WorkflowRunning && component is ConfigureNeuropixelsV2eHeadstage configureV2eHeadstage)
                 {
-                    using var editorDialog = new NeuropixelsV2eHeadstageDialog(configureHeadstage.NeuropixelsV2e, configureHeadstage.Bno055);
+                    using var editorDialog = new NeuropixelsV2eHeadstageDialog(configureV2eHeadstage.NeuropixelsV2e, configureV2eHeadstage.Bno055);
 
                     if (editorDialog.ShowDialog() == DialogResult.OK)
                     {
-                        configureHeadstage.Bno055.Enable = editorDialog.DialogBno055.ConfigureNode.Enable;
+                        configureV2eHeadstage.Bno055.Enable = editorDialog.DialogBno055.ConfigureNode.Enable;
 
-                        configureHeadstage.NeuropixelsV2e.Enable = editorDialog.DialogNeuropixelsV2e.ConfigureNode.Enable;
-                        configureHeadstage.NeuropixelsV2e.ProbeConfigurationA = editorDialog.DialogNeuropixelsV2e.ConfigureNode.ProbeConfigurationA;
-                        configureHeadstage.NeuropixelsV2e.ProbeConfigurationB = editorDialog.DialogNeuropixelsV2e.ConfigureNode.ProbeConfigurationB;
-                        configureHeadstage.NeuropixelsV2e.GainCalibrationFileA = editorDialog.DialogNeuropixelsV2e.ConfigureNode.GainCalibrationFileA;
-                        configureHeadstage.NeuropixelsV2e.GainCalibrationFileB = editorDialog.DialogNeuropixelsV2e.ConfigureNode.GainCalibrationFileB;
+                        configureV2eHeadstage.NeuropixelsV2e.Enable = editorDialog.DialogNeuropixelsV2e.ConfigureNode.Enable;
+                        configureV2eHeadstage.NeuropixelsV2e.ProbeConfigurationA = editorDialog.DialogNeuropixelsV2e.ConfigureNode.ProbeConfigurationA;
+                        configureV2eHeadstage.NeuropixelsV2e.ProbeConfigurationB = editorDialog.DialogNeuropixelsV2e.ConfigureNode.ProbeConfigurationB;
+                        configureV2eHeadstage.NeuropixelsV2e.GainCalibrationFileA = editorDialog.DialogNeuropixelsV2e.ConfigureNode.GainCalibrationFileA;
+                        configureV2eHeadstage.NeuropixelsV2e.GainCalibrationFileB = editorDialog.DialogNeuropixelsV2e.ConfigureNode.GainCalibrationFileB;
+
+                        return true;
+                    }
+                }
+                else if (editorState != null && !editorState.WorkflowRunning && component is ConfigureNeuropixelsV2eBetaHeadstage configureV2eBetaHeadstage)
+                {
+                    using var editorDialog = new NeuropixelsV2eHeadstageDialog(configureV2eBetaHeadstage.NeuropixelsV2eBeta, configureV2eBetaHeadstage.Bno055);
+
+                    if (editorDialog.ShowDialog() == DialogResult.OK)
+                    {
+                        configureV2eBetaHeadstage.Bno055.Enable = editorDialog.DialogBno055.ConfigureNode.Enable;
+
+                        configureV2eBetaHeadstage.NeuropixelsV2eBeta.Enable = editorDialog.DialogNeuropixelsV2e.ConfigureNode.Enable;
+                        configureV2eBetaHeadstage.NeuropixelsV2eBeta.ProbeConfigurationA = editorDialog.DialogNeuropixelsV2e.ConfigureNode.ProbeConfigurationA;
+                        configureV2eBetaHeadstage.NeuropixelsV2eBeta.ProbeConfigurationB = editorDialog.DialogNeuropixelsV2e.ConfigureNode.ProbeConfigurationB;
+                        configureV2eBetaHeadstage.NeuropixelsV2eBeta.GainCalibrationFileA = editorDialog.DialogNeuropixelsV2e.ConfigureNode.GainCalibrationFileA;
+                        configureV2eBetaHeadstage.NeuropixelsV2eBeta.GainCalibrationFileB = editorDialog.DialogNeuropixelsV2e.ConfigureNode.GainCalibrationFileB;
 
                         return true;
                     }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationEditor.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationEditor.cs
@@ -29,11 +29,16 @@ namespace OpenEphys.Onix1.Design
                 if (editorService != null && editorState != null && !editorState.WorkflowRunning &&
                     value is NeuropixelsV2QuadShankProbeConfiguration configuration)
                 {
-                    var instance = (ConfigureNeuropixelsV2e)context.Instance;
+                    var instance = (IConfigureNeuropixelsV2)context.Instance;
 
                     var calibrationFile = configuration.Probe == NeuropixelsV2Probe.ProbeA ? instance.GainCalibrationFileA : instance.GainCalibrationFileB;
 
                     using var editorDialog = new NeuropixelsV2eProbeConfigurationDialog(configuration, calibrationFile);
+
+                    if (instance is ConfigureNeuropixelsV2eBeta)
+                    {
+                        editorDialog.Text = editorDialog.Text.Replace("NeuropixelsV2e ", "NeuropixelsV2eBeta ");
+                    }
 
                     if (editorDialog.ShowDialog() == DialogResult.OK)
                     {

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -37,9 +37,7 @@ namespace OpenEphys.Onix1
             DeviceAddress = configureNode.DeviceAddress;
         }
 
-        /// <summary>
-        /// Gets or sets the device enable state.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// If set to true, <see cref="NeuropixelsV2eData"/> will produce data. If set to false, 
         /// <see cref="NeuropixelsV2eData"/> will not produce data.
@@ -48,9 +46,7 @@ namespace OpenEphys.Onix1
         [Description("Specifies whether the NeuropixelsV2 device is enabled.")]
         public bool Enable { get; set; } = true;
 
-        /// <summary>
-        /// Gets or sets the electrode configuration for Probe A.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
         /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationA"/> variable
@@ -62,9 +58,7 @@ namespace OpenEphys.Onix1
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationA { get; set; } = new(NeuropixelsV2Probe.ProbeA);
 
-        /// <summary>
-        /// Gets or sets the path to the gain calibration file for Probe A.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// <para>
         /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
@@ -83,9 +77,7 @@ namespace OpenEphys.Onix1
         [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public string GainCalibrationFileA { get; set; }
 
-        /// <summary>
-        /// Gets or sets the electrode configuration for Probe B.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
         /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationB"/> variable
@@ -97,9 +89,7 @@ namespace OpenEphys.Onix1
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationB { get; set; } = new(NeuropixelsV2Probe.ProbeB);
 
-        /// <summary>
-        /// Gets or sets the path to the gain calibration file for Probe B.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// <para>
         /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
     [Description("Configures a NeuropixelsV2e device.")]
-    public class ConfigureNeuropixelsV2e : SingleDeviceFactory
+    public class ConfigureNeuropixelsV2e : SingleDeviceFactory, IConfigureNeuropixelsV2
     {
         /// <summary>
         /// Initialize a new instance of a <see cref="ConfigureNeuropixelsV2e"/> class.

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -38,9 +38,7 @@ namespace OpenEphys.Onix1
             DeviceAddress = configureNode.DeviceAddress;
         }
 
-        /// <summary>
-        /// Gets or sets the device enable state.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// If set to true, <see cref="NeuropixelsV2eBetaData"/> will produce data. If set to false, 
         /// <see cref="NeuropixelsV2eBetaData"/> will not produce data.
@@ -59,9 +57,7 @@ namespace OpenEphys.Onix1
         [Description("If true, the headstage LED will turn on during data acquisition. If false, the LED will not turn on.")]
         public bool EnableLed { get; set; } = true;
 
-        /// <summary>
-        /// Gets or sets the electrode configuration for Probe A.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
         /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationA"/> variable
@@ -73,9 +69,7 @@ namespace OpenEphys.Onix1
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationA { get; set; } = new(NeuropixelsV2Probe.ProbeA);
 
-        /// <summary>
-        /// Gets or sets the path to the gain calibration file for Probe A.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// <para>
         /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during
@@ -94,9 +88,7 @@ namespace OpenEphys.Onix1
         [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public string GainCalibrationFileA { get; set; }
 
-        /// <summary>
-        /// Gets or sets the electrode configuration for Probe B.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
         /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationB"/> variable
@@ -108,9 +100,7 @@ namespace OpenEphys.Onix1
         [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationB { get; set; } = new(NeuropixelsV2Probe.ProbeB);
 
-        /// <summary>
-        /// Gets or sets the path to the gain calibration file for Probe B.
-        /// </summary>
+        /// <inheritdoc/>
         /// <remarks>
         /// <para>
         /// Each probe is linked to a gain calibration file that contains gain adjustments determined by IMEC during

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Drawing.Design;
 using System.Reactive.Disposables;
 using Bonsai;
 
@@ -9,7 +10,8 @@ namespace OpenEphys.Onix1
     /// A class that configures a NeuropixelsV2eBeta device.
     /// </summary>
     [Description("Configures a NeuropixelsV2eBeta device.")]
-    public class ConfigureNeuropixelsV2eBeta : SingleDeviceFactory
+    [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
+    public class ConfigureNeuropixelsV2eBeta : SingleDeviceFactory, IConfigureNeuropixelsV2
     {
         /// <summary>
         /// Initialize a new instance of a <see cref="ConfigureNeuropixelsV2eBeta"/> class.
@@ -17,6 +19,23 @@ namespace OpenEphys.Onix1
         public ConfigureNeuropixelsV2eBeta()
             : base(typeof(NeuropixelsV2eBeta))
         {
+        }
+
+        /// <summary>
+        /// Copy constructor for the <see cref="ConfigureNeuropixelsV2e"/> class.
+        /// </summary>
+        /// <param name="configureNode">A pre-existing <see cref="ConfigureNeuropixelsV2e"/> object.</param>
+        public ConfigureNeuropixelsV2eBeta(ConfigureNeuropixelsV2eBeta configureNode)
+            : base(typeof(NeuropixelsV2eBeta))
+        {
+            Enable = configureNode.Enable;
+            EnableLed = configureNode.EnableLed;
+            ProbeConfigurationA = configureNode.ProbeConfigurationA;
+            ProbeConfigurationB = configureNode.ProbeConfigurationB;
+            GainCalibrationFileA = configureNode.GainCalibrationFileA;
+            GainCalibrationFileB = configureNode.GainCalibrationFileB;
+            DeviceName = configureNode.DeviceName;
+            DeviceAddress = configureNode.DeviceAddress;
         }
 
         /// <summary>
@@ -43,8 +62,15 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Gets or sets the electrode configuration for Probe A.
         /// </summary>
+        /// <remarks>
+        /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
+        /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationA"/> variable
+        /// in the property pane, or double-click <see cref="ConfigureNeuropixelsV2eBetaHeadstage"/> to configure both
+        /// probes and the <see cref="ConfigureNeuropixelsV2eBno055"/> simultaneously.
+        /// </remarks>
         [Category(ConfigurationCategory)]
         [Description("Probe A electrode configuration.")]
+        [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationA { get; set; } = new(NeuropixelsV2Probe.ProbeA);
 
         /// <summary>
@@ -71,8 +97,15 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Gets or sets the electrode configuration for Probe B.
         /// </summary>
+        /// <remarks>
+        /// Configuration is accomplished using a GUI to aid in channel selection and relevant configuration properties.
+        /// To open a probe configuration GUI, select the ellipses next the <see cref="ProbeConfigurationB"/> variable
+        /// in the property pane, or double-click <see cref="ConfigureNeuropixelsV2eBetaHeadstage"/> to configure both
+        /// probes and the <see cref="ConfigureNeuropixelsV2eBno055"/> simultaneously.
+        /// </remarks>
         [Category(ConfigurationCategory)]
         [Description("Probe B electrode configuration.")]
+        [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eProbeConfigurationEditor, OpenEphys.Onix1.Design", typeof(UITypeEditor))]
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationB { get; set; } = new(NeuropixelsV2Probe.ProbeB);
 
         /// <summary>

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBetaHeadstage.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBetaHeadstage.cs
@@ -7,6 +7,7 @@ namespace OpenEphys.Onix1
     /// A class that configures a NeuropixelsV2eBeta headstage on the specified port.
     /// </summary>
     [Description("Configures a NeuropixelsV2eBeta headstage.")]
+    [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eHeadstageEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
     public class ConfigureNeuropixelsV2eBetaHeadstage : MultiDeviceFactory
     {
         PortName port;

--- a/OpenEphys.Onix1/IConfigureNeuropixelsV2.cs
+++ b/OpenEphys.Onix1/IConfigureNeuropixelsV2.cs
@@ -1,0 +1,11 @@
+﻿namespace OpenEphys.Onix1
+{
+    public interface IConfigureNeuropixelsV2
+    {
+        public bool Enable { get; set; }
+        public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationA { get; set; }
+        public string GainCalibrationFileA { get; set; }
+        public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationB { get; set; }
+        public string GainCalibrationFileB { get; set; }
+    }
+}

--- a/OpenEphys.Onix1/IConfigureNeuropixelsV2.cs
+++ b/OpenEphys.Onix1/IConfigureNeuropixelsV2.cs
@@ -1,11 +1,33 @@
 ﻿namespace OpenEphys.Onix1
 {
+    /// <summary>
+    /// Public interface that defines common properties in NeuropixelsV2 devices.
+    /// </summary>
     public interface IConfigureNeuropixelsV2
     {
+        /// <summary>
+        /// Gets or sets the device enable state.
+        /// </summary>
         public bool Enable { get; set; }
+
+        /// <summary>
+        /// Gets or sets the electrode configuration for Probe A.
+        /// </summary>
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationA { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the gain calibration file for Probe A.
+        /// </summary>
         public string GainCalibrationFileA { get; set; }
+
+        /// <summary>
+        /// Gets or sets the electrode configuration for Probe B.
+        /// </summary>
         public NeuropixelsV2QuadShankProbeConfiguration ProbeConfigurationB { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the gain calibration file for Probe B.
+        /// </summary>
         public string GainCalibrationFileB { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds GUIs for the `NeuropixelsV2eBeta` headstage. The added dialogs call the `NeuropixelsV2e` GUIs, taking advantage of the common interface between `ConfigureNeuropixelsV2e` and `ConfigureNeuropixelsV2eBeta`. When the underlying type is a `*Beta`, all relevant text strings are updated to reflect this.

Closes #227
Closes #268 
Fixes #202