### PR TITLE
Fix loading channel configuration files

### DIFF
--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -169,10 +169,10 @@ namespace OpenEphys.Onix1.Design
 
             public ProbeEdge(ZedGraphControl zedGraphControl)
             {
-                Left = GetProbeContourMinX(zedGraphControl.GraphPane.GraphObjList);
-                Right = GetProbeContourMaxX(zedGraphControl.GraphPane.GraphObjList);
-                Bottom = GetProbeContourMinY(zedGraphControl.GraphPane.GraphObjList);
-                Top = GetProbeContourMaxY(zedGraphControl.GraphPane.GraphObjList);
+                Left = GetProbeMinX(zedGraphControl.GraphPane.GraphObjList);
+                Right = GetProbeMaxX(zedGraphControl.GraphPane.GraphObjList);
+                Bottom = GetProbeMinY(zedGraphControl.GraphPane.GraphObjList);
+                Top = GetProbeMaxY(zedGraphControl.GraphPane.GraphObjList);
             }
         }
 
@@ -475,9 +475,9 @@ namespace OpenEphys.Onix1.Design
             zedGraphChannels.GraphPane.GraphObjList.Clear();
 
             DrawProbeContour();
+            DrawContacts();
             SetEqualAspectRatio();
             SetZoomOutBoundaries();
-            DrawContacts();
             HighlightEnabledContacts();
             HighlightSelectedContacts();
             DrawContactLabels();
@@ -527,10 +527,10 @@ namespace OpenEphys.Onix1.Design
             if (zedGraphChannels.GraphPane.GraphObjList.Count == 0)
                 return;
 
-            var minX = GetProbeContourMinX(zedGraphChannels.GraphPane.GraphObjList);
-            var minY = GetProbeContourMinY(zedGraphChannels.GraphPane.GraphObjList);
-            var maxX = GetProbeContourMaxX(zedGraphChannels.GraphPane.GraphObjList);
-            var maxY = GetProbeContourMaxY(zedGraphChannels.GraphPane.GraphObjList);
+            var minX = GetProbeMinX(zedGraphChannels.GraphPane.GraphObjList);
+            var minY = GetProbeMinY(zedGraphChannels.GraphPane.GraphObjList);
+            var maxX = GetProbeMaxX(zedGraphChannels.GraphPane.GraphObjList);
+            var maxY = GetProbeMaxY(zedGraphChannels.GraphPane.GraphObjList);
 
             var rangeX = maxX - minX;
             var rangeY = maxY - minY;
@@ -808,11 +808,51 @@ namespace OpenEphys.Onix1.Design
 
             return 1f;
         }
+        // TODO: Convert from MinX/MaxX/... to Left / Right / etc.
+        internal static double GetProbeMinX(GraphObjList graphObjs)
+        {
+            if (graphObjs == null || graphObjs.Count == 0) return 0f;
+
+            if (graphObjs.OfType<PolyObj>().Count() == 0)
+            {
+                return GetContactMinX(graphObjs);
+            }
+            else
+            {
+                return GetProbeContourMinX(graphObjs);
+            }
+        }
+
+        internal static double GetContactMinX(GraphObjList graphObjs)
+        {
+            return graphObjs.OfType<BoxObj>()
+                            .Min(obj => { return obj.Location.Rect.Left; });
+        }
 
         internal static double GetProbeContourMinX(GraphObjList graphObjs)
         {
             return graphObjs.OfType<PolyObj>()
                             .Min(obj => { return obj.Points.Min(p => p.X); });
+        }
+
+        internal static double GetProbeMinY(GraphObjList graphObjs)
+        {
+            if (graphObjs == null || graphObjs.Count == 0) return 0f;
+
+            if (graphObjs.OfType<PolyObj>().Count() == 0)
+            {
+                return GetContactMinY(graphObjs);
+            }
+            else
+            {
+                return GetProbeContourMinY(graphObjs);
+            }
+        }
+
+        internal static double GetContactMinY(GraphObjList graphObjs)
+        {
+            return graphObjs.OfType<BoxObj>()
+                            .Min(obj => { return obj.Location.Rect.Bottom; });
         }
 
         internal static double GetProbeContourMinY(GraphObjList graphObjs)
@@ -821,10 +861,50 @@ namespace OpenEphys.Onix1.Design
                             .Min(obj => { return obj.Points.Min(p => p.Y); });
         }
 
+        internal static double GetProbeMaxX(GraphObjList graphObjs)
+        {
+            if (graphObjs == null || graphObjs.Count == 0) return 0f;
+
+            if (graphObjs.OfType<PolyObj>().Count() == 0)
+            {
+                return GetContactMaxX(graphObjs);
+            }
+            else
+            {
+                return GetProbeContourMaxX(graphObjs);
+            }
+        }
+
+        internal static double GetContactMaxX(GraphObjList graphObjs)
+        {
+            return graphObjs.OfType<BoxObj>()
+                            .Max(obj => { return obj.Location.Rect.Right; });
+        }
+
         internal static double GetProbeContourMaxX(GraphObjList graphObjs)
         {
             return graphObjs.OfType<PolyObj>()
                             .Max(obj => { return obj.Points.Max(p => p.X); });
+        }
+
+        internal static double GetProbeMaxY(GraphObjList graphObjs)
+        {
+            if (graphObjs == null || graphObjs.Count == 0) return 0f;
+
+            if (graphObjs.OfType<PolyObj>().Count() == 0)
+            {
+                return GetContactMaxY(graphObjs);
+            }
+            else
+            {
+                return GetProbeContourMaxY(graphObjs);
+            }
+        }
+
+        internal static double GetContactMaxY(GraphObjList graphObjs)
+        {
+            return graphObjs.OfType<BoxObj>()
+                            .Max(obj => { return obj.Location.Rect.Top; });
         }
 
         internal static double GetProbeContourMaxY(GraphObjList graphObjs)
@@ -1023,8 +1103,8 @@ namespace OpenEphys.Onix1.Design
 
             var currentRange = zedGraphChannels.GraphPane.YAxis.Scale.Max - zedGraphChannels.GraphPane.YAxis.Scale.Min;
 
-            var minY = GetProbeContourMinY(zedGraphChannels.GraphPane.GraphObjList);
-            var maxY = GetProbeContourMaxY(zedGraphChannels.GraphPane.GraphObjList);
+            var minY = GetProbeMinY(zedGraphChannels.GraphPane.GraphObjList);
+            var maxY = GetProbeMaxY(zedGraphChannels.GraphPane.GraphObjList);
 
             var newMinY = (maxY - minY - currentRange) * relativePosition;
 
@@ -1034,8 +1114,8 @@ namespace OpenEphys.Onix1.Design
 
         internal float GetRelativeVerticalPosition()
         {
-            var minY = GetProbeContourMinY(zedGraphChannels.GraphPane.GraphObjList);
-            var maxY = GetProbeContourMaxY(zedGraphChannels.GraphPane.GraphObjList);
+            var minY = GetProbeMinY(zedGraphChannels.GraphPane.GraphObjList);
+            var maxY = GetProbeMaxY(zedGraphChannels.GraphPane.GraphObjList);
 
             var currentRange = zedGraphChannels.GraphPane.YAxis.Scale.Max - zedGraphChannels.GraphPane.YAxis.Scale.Min;
 

--- a/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/ChannelConfigurationDialog.cs
@@ -584,6 +584,8 @@ namespace OpenEphys.Onix1.Design
 
                         contactObj.Border.Width = borderWidth;
                         contactObj.Border.IsVisible = false;
+                        contactObj.Location.AlignV = AlignV.Center;
+                        contactObj.Location.AlignH = AlignH.Center;
 
                         zedGraphChannels.GraphPane.GraphObjList.Add(contactObj);
                     }
@@ -599,6 +601,8 @@ namespace OpenEphys.Onix1.Design
 
                         contactObj.Border.Width = borderWidth;
                         contactObj.Border.IsVisible = false;
+                        contactObj.Location.AlignV = AlignV.Bottom;
+                        contactObj.Location.AlignH = AlignH.Left;
 
                         zedGraphChannels.GraphPane.GraphObjList.Add(contactObj);
                     }
@@ -852,7 +856,7 @@ namespace OpenEphys.Onix1.Design
         internal static double GetContactMinY(GraphObjList graphObjs)
         {
             return graphObjs.OfType<BoxObj>()
-                            .Min(obj => { return obj.Location.Rect.Bottom; });
+                            .Min(obj => { return obj.Location.Rect.Top - obj.Location.Height; });
         }
 
         internal static double GetProbeContourMinY(GraphObjList graphObjs)
@@ -904,7 +908,7 @@ namespace OpenEphys.Onix1.Design
         internal static double GetContactMaxY(GraphObjList graphObjs)
         {
             return graphObjs.OfType<BoxObj>()
-                            .Max(obj => { return obj.Location.Rect.Top; });
+                            .Max(obj => { return obj.Location.Rect.Bottom - obj.Location.Height; });
         }
 
         internal static double GetProbeContourMaxY(GraphObjList graphObjs)

--- a/OpenEphys.Onix1.Design/DesignHelper.cs
+++ b/OpenEphys.Onix1.Design/DesignHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,10 +9,38 @@ namespace OpenEphys.Onix1.Design
 {
     static class DesignHelper
     {
-        public static T DeserializeString<T>(string channelLayout)
+        /// <summary>
+        /// Given a string with a valid JSON structure, deserialize the string to the given type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="channelLayout"></param>
+        /// <returns></returns>
+        #nullable enable
+        public static T? DeserializeString<T>(string channelLayout)
         {
-            return JsonConvert.DeserializeObject<T>(channelLayout);
+            var errors = new List<string>();
+
+            var serializerSettings = new JsonSerializerSettings()
+            {
+                Error = delegate(object sender, Newtonsoft.Json.Serialization.ErrorEventArgs args)
+                {
+                    errors.Add(args.ErrorContext.Error.Message);
+                    args.ErrorContext.Handled = true;
+                }
+            };
+
+            var obj = JsonConvert.DeserializeObject<T>(channelLayout, serializerSettings);
+
+            if (errors.Count > 0)
+            {
+                MessageBox.Show($"Warning: There were {errors.Count} errors found while deserializing the JSON string.\n" +
+                    $"The first error was '{errors.First()}'.", "Deserializer Error");
+                return default;
+            }
+
+            return obj;
         }
+        #nullable disable
 
         public static void SerializeObject(object _object, string filepath)
         {

--- a/OpenEphys.Onix1.Design/DesignHelper.cs
+++ b/OpenEphys.Onix1.Design/DesignHelper.cs
@@ -33,8 +33,14 @@ namespace OpenEphys.Onix1.Design
 
             if (errors.Count > 0)
             {
-                MessageBox.Show($"Warning: There were {errors.Count} errors found while deserializing the JSON string.\n" +
-                    $"The first error was '{errors.First()}'.", "Deserializer Error");
+                MessageBox.Show($"There were errors encountered while parsing a JSON string. Check the console " +
+                    $"for an error log.", "JSON Parse Error");
+
+                foreach (var e in errors)
+                {
+                    Console.Error.WriteLine(e);
+                }
+
                 return default;
             }
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eChannelConfigurationDialog.cs
@@ -127,9 +127,9 @@ namespace OpenEphys.Onix1.Design
             var majorTickOffset = MajorTickLength + CalculateScaleRange(zedGraphChannels.GraphPane.XAxis.Scale) * 0.015;
             majorTickOffset = majorTickOffset > 50 ? 50 : majorTickOffset;
 
-            var x = GetProbeContourMaxX(zedGraphChannels.GraphPane.GraphObjList) + 40;
-            var minY = GetProbeContourMinY(zedGraphChannels.GraphPane.GraphObjList);
-            var maxY = GetProbeContourMaxY(zedGraphChannels.GraphPane.GraphObjList);
+            var x = GetProbeMaxX(zedGraphChannels.GraphPane.GraphObjList) + 40;
+            var minY = GetProbeMinY(zedGraphChannels.GraphPane.GraphObjList);
+            var maxY = GetProbeMaxY(zedGraphChannels.GraphPane.GraphObjList);
 
             PointPairList pointList = new();
 

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eChannelConfigurationDialog.cs
@@ -131,6 +131,8 @@ namespace OpenEphys.Onix1.Design
             var minY = GetProbeMinY(zedGraphChannels.GraphPane.GraphObjList);
             var maxY = GetProbeMaxY(zedGraphChannels.GraphPane.GraphObjList);
 
+            int textPosition = 0;
+
             PointPairList pointList = new();
 
             var countMajorTicks = 0;
@@ -143,15 +145,17 @@ namespace OpenEphys.Onix1.Design
                 pointList.Add(majorTickLocation);
                 pointList.Add(new PointPair(x, minY + MajorTickIncrement * countMajorTicks));
 
-                if (!zoomedOut || i % (5 * MajorTickIncrement) == 0)
+                if (!zoomedOut || countMajorTicks % 5 == 0)
                 {
-                    TextObj textObj = new($"{i} µm", majorTickLocation.X + 10, majorTickLocation.Y, CoordType.AxisXYScale, AlignH.Left, AlignV.Center)
+                    TextObj textObj = new($"{textPosition} µm", majorTickLocation.X + 10, majorTickLocation.Y, CoordType.AxisXYScale, AlignH.Left, AlignV.Center)
                     {
                         Tag = ScaleTextTag
                     };
                     textObj.FontSpec.Border.IsVisible = false;
                     textObj.FontSpec.Size = fontSize;
                     zedGraphChannels.GraphPane.GraphObjList.Add(textObj);
+
+                    textPosition += zoomedOut ? 5 * MajorTickIncrement : MajorTickIncrement;
                 }
 
                 if (!zoomedOut)

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eChannelConfigurationDialog.cs
@@ -62,14 +62,19 @@ namespace OpenEphys.Onix1.Design
             OnFileOpenHandler();
         }
 
-        internal override void OpenFile<T>()
+        internal override bool OpenFile<T>()
         {
-            base.OpenFile<NeuropixelsV1eProbeGroup>();
+            if (base.OpenFile<NeuropixelsV1eProbeGroup>())
+            {
+                ProbeConfiguration = new((NeuropixelsV1eProbeGroup)ChannelConfiguration, ProbeConfiguration.SpikeAmplifierGain, ProbeConfiguration.LfpAmplifierGain, ProbeConfiguration.Reference, ProbeConfiguration.SpikeFilter);
+                ChannelConfiguration = ProbeConfiguration.ChannelConfiguration;
 
-            ProbeConfiguration = new((NeuropixelsV1eProbeGroup)ChannelConfiguration, ProbeConfiguration.SpikeAmplifierGain, ProbeConfiguration.LfpAmplifierGain, ProbeConfiguration.Reference, ProbeConfiguration.SpikeFilter);
-            ChannelConfiguration = ProbeConfiguration.ChannelConfiguration;
+                OnFileOpenHandler();
 
-            OnFileOpenHandler();
+                return true;
+            }
+
+            return false;
         }
 
         private void OnFileOpenHandler()

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
@@ -54,38 +54,22 @@ namespace OpenEphys.Onix1.Design
             ProbeConfiguration = new(ProbeConfiguration.Probe, ProbeConfiguration.Reference);
             ChannelConfiguration = ProbeConfiguration.ChannelConfiguration;
 
-            DrawProbeGroup();
-            RefreshZedGraph();
-
             OnFileOpenHandler();
         }
 
-        internal override void OpenFile<T>()
+        internal override bool OpenFile<T>()
         {
-            var newConfiguration = OpenAndParseConfigurationFile<NeuropixelsV2eProbeGroup>();
-
-            if (newConfiguration == null)
+            if (base.OpenFile<NeuropixelsV2eProbeGroup>())
             {
-                return;
-            }
-
-            if (ProbeConfiguration.ChannelConfiguration.NumberOfContacts == newConfiguration.NumberOfContacts)
-            {
-                newConfiguration.Validate();
-
-                ProbeConfiguration = new(newConfiguration, ProbeConfiguration.Reference, ProbeConfiguration.Probe);
+                ProbeConfiguration = new((NeuropixelsV2eProbeGroup)ChannelConfiguration, ProbeConfiguration.Reference, ProbeConfiguration.Probe);
                 ChannelConfiguration = ProbeConfiguration.ChannelConfiguration;
 
-                DrawProbeGroup();
-                RefreshZedGraph();
-            }
-            else
-            {
-                throw new InvalidOperationException($"Number of contacts does not match; expected {ProbeConfiguration.ChannelConfiguration.NumberOfContacts} contacts" +
-                    $", but found {newConfiguration.NumberOfContacts} contacts");
+                OnFileOpenHandler();
+
+                return true;
             }
 
-            OnFileOpenHandler();
+            return false;
         }
 
         private void OnFileOpenHandler()

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
@@ -125,6 +125,8 @@ namespace OpenEphys.Onix1.Design
             var minY = GetProbeMinY(zedGraphChannels.GraphPane.GraphObjList);
             var maxY = GetProbeMaxY(zedGraphChannels.GraphPane.GraphObjList);
 
+            int textPosition = 0;
+
             PointPairList pointList = new();
 
             var countMajorTicks = 0;
@@ -137,15 +139,17 @@ namespace OpenEphys.Onix1.Design
                 pointList.Add(majorTickLocation);
                 pointList.Add(new PointPair(x, minY + MajorTickIncrement * countMajorTicks));
 
-                if (!zoomedOut || i % (5 * MajorTickIncrement) == 0)
+                if (!zoomedOut || countMajorTicks % 5 == 0)
                 {
-                    TextObj textObj = new($"{i} µm\n", majorTickLocation.X + 5, majorTickLocation.Y, CoordType.AxisXYScale, AlignH.Left, AlignV.Center)
+                    TextObj textObj = new($"{textPosition} µm\n", majorTickLocation.X + 5, majorTickLocation.Y, CoordType.AxisXYScale, AlignH.Left, AlignV.Center)
                     {
                         Tag = ScaleTextTag,
                     };
                     textObj.FontSpec.Border.IsVisible = false;
                     textObj.FontSpec.Size = fontSize;
                     zedGraphChannels.GraphPane.GraphObjList.Add(textObj);
+
+                    textPosition += zoomedOut ? 5 * MajorTickIncrement : MajorTickIncrement;
                 }
 
                 if (!zoomedOut)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eChannelConfigurationDialog.cs
@@ -62,7 +62,6 @@ namespace OpenEphys.Onix1.Design
             if (base.OpenFile<NeuropixelsV2eProbeGroup>())
             {
                 ProbeConfiguration = new((NeuropixelsV2eProbeGroup)ChannelConfiguration, ProbeConfiguration.Reference, ProbeConfiguration.Probe);
-                ChannelConfiguration = ProbeConfiguration.ChannelConfiguration;
 
                 OnFileOpenHandler();
 
@@ -122,9 +121,9 @@ namespace OpenEphys.Onix1.Design
             var majorTickOffset = MajorTickLength + CalculateScaleRange(zedGraphChannels.GraphPane.XAxis.Scale) * 0.015;
             majorTickOffset = majorTickOffset > 50 ? 50 : majorTickOffset;
 
-            var x = GetProbeContourMaxX(zedGraphChannels.GraphPane.GraphObjList) + 50;
-            var minY = GetProbeContourMinY(zedGraphChannels.GraphPane.GraphObjList);
-            var maxY = GetProbeContourMaxY(zedGraphChannels.GraphPane.GraphObjList);
+            var x = GetProbeMaxX(zedGraphChannels.GraphPane.GraphObjList) + 50;
+            var minY = GetProbeMinY(zedGraphChannels.GraphPane.GraphObjList);
+            var maxY = GetProbeMaxY(zedGraphChannels.GraphPane.GraphObjList);
 
             PointPairList pointList = new();
 
@@ -166,13 +165,14 @@ namespace OpenEphys.Onix1.Design
                 countMajorTicks++;
             }
 
-            var curve = zedGraphChannels.GraphPane.AddCurve(ScalePointsTag, pointList, Color.Black, SymbolType.None);
+            var curve = zedGraphChannels.GraphPane.AddCurve("", pointList, Color.Black, SymbolType.None);
 
             const float scaleBarWidth = 1;
 
             curve.Line.Width = scaleBarWidth; 
             curve.Label.IsVisible = false;
             curve.Symbol.IsVisible = false;
+            curve.Tag = ScalePointsTag;
         }
 
         internal override void HighlightEnabledContacts()

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -66,7 +66,7 @@ namespace OpenEphys.Onix1.Design
             {
                 NeuropixelsV2Probe.ProbeA => "Probe A",
                 NeuropixelsV2Probe.ProbeB => "Probe B",
-                _ => throw new ArgumentException("Invalid probe was specified.")
+                _ => "Invalid probe was specified."
             };
         }
 

--- a/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
+++ b/OpenEphys.Onix1.Design/OpenEphys.Onix1.Design.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Bonsai.Design" Version="2.8.5" />
     <PackageReference Include="Bonsai.Design.Visualizers" Version="2.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.1.0" />
+    <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.1.1" />
     <PackageReference Include="ZedGraph" Version="5.1.7" />
   </ItemGroup>
 

--- a/OpenEphys.Onix1/NeuropixelsV1Helper.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1Helper.cs
@@ -20,14 +20,24 @@ namespace OpenEphys.Onix1
         /// <exception cref="InvalidOperationException"></exception>
         public static NeuropixelsV1eAdcCalibration ParseAdcCalibrationFile(StreamReader file)
         {
+            // TODO: "file" input argument should either be a FileStream or a path string. StreamReader is to
+            // general because cal data is always provided in a file and this function call expects to start
+            // from the beginning of the stream. This will require a change in the public API.
+
             if (file == null || file.EndOfStream)
             {
                 throw new ArgumentException("Incoming stream reader is not pointing to a valid ADC calibration file.");
             }
 
-            var adcSerialNumber = ulong.Parse(file.ReadLine());
+            string path = (file.BaseStream as FileStream)?.Name;
 
-            NeuropixelsV1eAdc[] adcs = new NeuropixelsV1eAdc[NeuropixelsV1e.AdcCount];
+            if (!ulong.TryParse(file.ReadLine(), out ulong adcSerialNumber))
+            {
+                throw new ArgumentException($"The calibration file {path} specified is " +
+                    $"incorrectly formatted.");
+            }
+
+            var adcs = new NeuropixelsV1eAdc[NeuropixelsV1e.AdcCount];
 
             for (var i = 0; i < NeuropixelsV1e.AdcCount; i++)
             {
@@ -64,12 +74,22 @@ namespace OpenEphys.Onix1
         /// <exception cref="InvalidOperationException"></exception>
         public static NeuropixelsV1eGainCorrection ParseGainCalibrationFile(StreamReader file, NeuropixelsV1Gain apGain, NeuropixelsV1Gain lfpGain)
         {
+            // TODO: "file" input argument should either be a FileStream or a path string. StreamReader is to
+            // general because cal data is always provided in a file and this function call expects to start
+            // from the beginning of the stream. This will require a change in the public API.
+
             if (file == null || file.EndOfStream)
             {
                 throw new ArgumentException("Incoming stream reader is not pointing to a valid gain calibration file.");
             }
 
-            var serialNumber = ulong.Parse(file.ReadLine());
+            string path = (file.BaseStream as FileStream)?.Name;
+
+            if (!ulong.TryParse(file.ReadLine(), out ulong serialNumber))
+            {
+                throw new ArgumentException($"The calibration file {path} specified is " +
+                    $"incorrectly formatted.");
+            }
 
             var gainCorrections = file.ReadLine().Split(',').Skip(1);
 

--- a/OpenEphys.Onix1/NeuropixelsV1eRegisterContext.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eRegisterContext.cs
@@ -38,10 +38,8 @@ namespace OpenEphys.Onix1
                     $"{probeSerialNumber}");
             }
 
-            StreamReader adcFile = new(adcCalibrationFile);
-
             // parse ADC calibration file
-            var adcCalibration = NeuropixelsV1Helper.ParseAdcCalibrationFile(adcFile);
+            var adcCalibration = NeuropixelsV1Helper.ParseAdcCalibrationFile(new StreamReader(adcCalibrationFile)); 
 
             if (adcCalibration.SN != probeSerialNumber)
             {
@@ -49,10 +47,10 @@ namespace OpenEphys.Onix1
                     $"match the ADC calibration file serial number: {adcCalibration.SN}.");
             }
 
-            StreamReader gainFile = new(gainCalibrationFile);
-
+            
             // parse gain correction file
-            var gainCorrection = NeuropixelsV1Helper.ParseGainCalibrationFile(gainFile, probeConfiguration.SpikeAmplifierGain, probeConfiguration.LfpAmplifierGain);
+            var gainCorrection = NeuropixelsV1Helper.ParseGainCalibrationFile(new StreamReader(gainCalibrationFile), 
+                probeConfiguration.SpikeAmplifierGain, probeConfiguration.LfpAmplifierGain);
 
             if (gainCorrection.SN != probeSerialNumber)
             {

--- a/OpenEphys.Onix1/NeuropixelsV2.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2.cs
@@ -35,7 +35,6 @@ namespace OpenEphys.Onix1
         public const int DummyRegisterCount = 4;
         public const int RegistersPerShank = ElectrodePerShank + ReferencePixelCount + DummyRegisterCount;
 
-
         internal static BitArray[] GenerateShankBits(NeuropixelsV2QuadShankProbeConfiguration probe)
         {
             BitArray[] shankBits =
@@ -124,7 +123,11 @@ namespace OpenEphys.Onix1
             }
 
             var gainFile = new StreamReader(gainCalibrationFile);
-            var sn = ulong.Parse(gainFile.ReadLine());
+            if(!ulong.TryParse(gainFile.ReadLine(), out ulong sn))
+            {
+                throw new ArgumentException($"The calibration file {gainCalibrationFile} specified for {probe} is " +
+                    $"incorrectly formatted.");
+            }
 
             if (probeSerialNumber != sn)
             {

--- a/OpenEphys.Onix1/NeuropixelsV2QuadShankProbeConfiguration.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2QuadShankProbeConfiguration.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using System.Text;
 using System.Xml.Serialization;
 using System.Linq;
+using OpenEphys.ProbeInterface.NET;
 
 namespace OpenEphys.Onix1
 {
@@ -124,8 +125,8 @@ namespace OpenEphys.Onix1
         public NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2QuadShankProbeConfiguration probeConfiguration)
         {
             Reference = probeConfiguration.Reference;
-            ChannelConfiguration = new();
-            ChannelConfiguration.UpdateDeviceChannelIndices(probeConfiguration.ChannelMap);
+            var probes = probeConfiguration.ChannelConfiguration.Probes.ToList().Select(probe => new Probe(probe));
+            ChannelConfiguration = new(probeConfiguration.ChannelConfiguration.Specification, probeConfiguration.ChannelConfiguration.Version, probes.ToArray());
             ChannelMap = NeuropixelsV2eProbeGroup.ToChannelMap(ChannelConfiguration);
             Probe = probeConfiguration.Probe;
         }
@@ -142,8 +143,7 @@ namespace OpenEphys.Onix1
         public NeuropixelsV2QuadShankProbeConfiguration(NeuropixelsV2eProbeGroup channelConfiguration, NeuropixelsV2QuadShankReference reference, NeuropixelsV2Probe probe)
         {
             ChannelMap = NeuropixelsV2eProbeGroup.ToChannelMap(channelConfiguration);
-            ChannelConfiguration = new();
-            ChannelConfiguration.UpdateDeviceChannelIndices(ChannelMap);
+            ChannelConfiguration = channelConfiguration;
             Reference = reference;
             Probe = probe;
         }

--- a/OpenEphys.Onix1/OpenEphys.Onix1.csproj
+++ b/OpenEphys.Onix1/OpenEphys.Onix1.csproj
@@ -13,6 +13,6 @@
     <PackageReference Include="Bonsai.Core" Version="2.8.5" />
     <PackageReference Include="clroni" Version="6.1.2" />
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
-    <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.1.0" />
+    <PackageReference Include="OpenEphys.ProbeInterface.NET" Version="0.1.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In this PR, channel configuration files that are malformed or are missing required fields no longer throw an exception that forcibly closes the dialog. Exceptions are routed appropriately to notify the user instead. 

Fixes #252

Additionally, files that contain changes other than the device channel indices are now respected. Previously, only the device channel indices were being saved, which meant that channels could be enabled and disabled by reading in a configuration file, but if the probe contour or contact shapes were modified those changes were not reflected in the GUI.

Fixes #271 

Finally, an emergent property of fixing #271 led to a bug in drawing the scale bar after loading files without a probe contour. This has been addressed as well in this PR, but no issue was created for it.