### PR TITLE
Standardize names for Neuropixels probes

### DIFF
--- a/OpenEphys.Onix1/NeuropixelsV1eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eProbeGroup.cs
@@ -20,7 +20,7 @@ namespace OpenEphys.Onix1
                   {
                       new(ProbeNdim.Two,
                           ProbeSiUnits.um,
-                          new ProbeAnnotations("Neuropixels 1.0e", "IMEC"),
+                          new ProbeAnnotations("Neuropixels 1.0", "IMEC"),
                           new ContactAnnotations(new string[0]),
                           DefaultContactPositions(NeuropixelsV1e.ElectrodeCount),
                           Probe.DefaultContactPlaneAxes(NeuropixelsV1e.ElectrodeCount),

--- a/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
@@ -29,7 +29,7 @@ namespace OpenEphys.Onix1
                   {
                       new(ProbeNdim.Two,
                           ProbeSiUnits.um,
-                          new ProbeAnnotations("Neuropixels 2.0e", "IMEC"),
+                          new ProbeAnnotations("Neuropixels 2.0 4-shank", "IMEC"),
                           new ContactAnnotations(new string[0]),
                           DefaultContactPositions(NeuropixelsV2.ElectrodePerShank * numberOfShanks),
                           Probe.DefaultContactPlaneAxes(NeuropixelsV2.ElectrodePerShank * numberOfShanks),

--- a/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eProbeGroup.cs
@@ -29,7 +29,7 @@ namespace OpenEphys.Onix1
                   {
                       new(ProbeNdim.Two,
                           ProbeSiUnits.um,
-                          new ProbeAnnotations("Neuropixels 2.0 4-shank", "IMEC"),
+                          new ProbeAnnotations("Neuropixels 2.0 - Multishank", "IMEC"),
                           new ContactAnnotations(new string[0]),
                           DefaultContactPositions(NeuropixelsV2.ElectrodePerShank * numberOfShanks),
                           Probe.DefaultContactPlaneAxes(NeuropixelsV2.ElectrodePerShank * numberOfShanks),


### PR DESCRIPTION
This PR aims to standardize the names for Neuropixels probes. Previously, the names were specific to ONIX devices instead of the probes themselves (i.e., `Neuropixels 2.0e` instead of `Neuropixels 2.0 4-shank`).

Fixes #270 