### PR TITLE
Fix register write in NP2.0-beta streamong configuration

### DIFF
--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -257,7 +257,7 @@ namespace OpenEphys.Onix1
         static void ConfigureProbeStreaming(I2CRegisterContext i2cNP)
         {
             // Activate recording mode on NP
-            i2cNP.WriteByte(NeuropixelsV2eBeta.REC_MODE, 0b0100_0000);
+            i2cNP.WriteByte(NeuropixelsV2eBeta.OP_MODE, 0b0100_0000);
 
             // Set global ADC settings
             i2cNP.WriteByte(NeuropixelsV2eBeta.ADC_CONFIG, 0b0000_1000);


### PR DESCRIPTION
- I was writing NeuropixelsV2eBeta.REC_MODE instead of NeuropixelsV2eBeta.OP_MODE which was preventing the probes from streaming data.
- Fixes #284 