### PR TITLE
Improve the shutdown behavior

### DIFF
--- a/OpenEphys.Onix1/ConfigurePortController.cs
+++ b/OpenEphys.Onix1/ConfigurePortController.cs
@@ -51,7 +51,9 @@ namespace OpenEphys.Onix1
                 var portShift = ((int)deviceAddress - 1) * 2;
                 var passthroughState = (hubConfiguration == HubConfiguration.Passthrough ? 1 : 0) << portShift;
                 context.HubState = (PassthroughState)(((int)context.HubState & ~(1 << portShift)) | passthroughState);
-                return Disposable.Empty;
+
+                // leave in standard mode when finished
+                return Disposable.Create(() => context.HubState = (PassthroughState)((int)context.HubState & ~(1 << portShift))); 
             })
             .ConfigureLink(context =>
             {


### PR DESCRIPTION
- This commit addresses two issues
- The first is that if there was an exception setting block read or write sizes, contextConfiguration within ContextTask was not disposed. This lead to a deadlock that required the process to be restarted even if the offending parameter was changed.
- When addressing this, I noticed that there may be a more general issue that is documented on line 314 of ContextTask. The general issue is that contextConfiguration must always be disposed, and there are (unlikely) ways that it might not be.
- Additionally, I improved the error messages presented when a ReadSize or WriteSize exception occurred indicating what value the user needs to use.
- The second issue was that when a hub was configured as a passthrough device, it was not reset to a stanard hub when acqusition was stopped. This could cause issues because the raw device used by passthroughs is a member of hub zero and could lead to huge required block read sizes even a headstage was no longer present. To address this, I simply returned an active disposable whose action is to reset the port to standard mode fro source.CoonfigureHost in ConfigurePortController, rather than Disposable.Empty, which did nothing.