### PR TITLE
Document how DeviceName links configuration and data IO operators

### DIFF
--- a/OpenEphys.Onix1/Bno055Data.cs
+++ b/OpenEphys.Onix1/Bno055Data.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration operator, such as a <see
-    /// cref="ConfigureBno055"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureBno055"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of 3D orientation measurements produced by a Bno055 9-axis inertial measurement unit.")]
     public class Bno055Data : Source<Bno055DataFrame>

--- a/OpenEphys.Onix1/Bno055Data.cs
+++ b/OpenEphys.Onix1/Bno055Data.cs
@@ -10,8 +10,8 @@ namespace OpenEphys.Onix1
     /// Produces a sequence of 3D orientation measurements produced by Bno055 9-axis inertial measurement unit.
     /// </summary>
     /// <remarks>
-    /// This data stream operator must be linked to an appropriate configuration, such as a <see cref="ConfigureBno055"/>,
-    /// in order to stream 3D orientation data.
+    /// This data IO operator must be linked to an appropriate configuration operator, such as a <see
+    /// cref="ConfigureBno055"/>, using a shared <see cref="DeviceName"/>.
     /// </remarks>
     [Description("Produces a sequence of 3D orientation measurements produced by a Bno055 9-axis inertial measurement unit.")]
     public class Bno055Data : Source<Bno055DataFrame>

--- a/OpenEphys.Onix1/BreakoutAnalogInput.cs
+++ b/OpenEphys.Onix1/BreakoutAnalogInput.cs
@@ -14,7 +14,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureBreakoutAnalogIO"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureBreakoutAnalogIO"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of analog input frames from an ONIX breakout board.")]
     public class BreakoutAnalogInput : Source<BreakoutAnalogInputDataFrame>

--- a/OpenEphys.Onix1/BreakoutAnalogInput.cs
+++ b/OpenEphys.Onix1/BreakoutAnalogInput.cs
@@ -12,6 +12,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Produces a sequence of analog input frames from an ONIX breakout board.
     /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureBreakoutAnalogIO"/>, using a shared <see cref="DeviceName"/>.
+    /// </remarks>
     [Description("Produces a sequence of analog input frames from an ONIX breakout board.")]
     public class BreakoutAnalogInput : Source<BreakoutAnalogInputDataFrame>
     {

--- a/OpenEphys.Onix1/BreakoutAnalogOutput.cs
+++ b/OpenEphys.Onix1/BreakoutAnalogOutput.cs
@@ -12,7 +12,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureBreakoutAnalogIO"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureBreakoutAnalogIO"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Sends analog output data to an ONIX breakout board.")]
     public class BreakoutAnalogOutput : Sink<Mat>

--- a/OpenEphys.Onix1/BreakoutAnalogOutput.cs
+++ b/OpenEphys.Onix1/BreakoutAnalogOutput.cs
@@ -10,6 +10,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Sends analog output data to an ONIX breakout board.
     /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureBreakoutAnalogIO"/>, using a shared <see cref="DeviceName"/>.
+    /// </remarks>
     [Description("Sends analog output data to an ONIX breakout board.")]
     public class BreakoutAnalogOutput : Sink<Mat>
     {

--- a/OpenEphys.Onix1/BreakoutDigitalInput.cs
+++ b/OpenEphys.Onix1/BreakoutDigitalInput.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureBreakoutDigitalIO"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureBreakoutDigitalIO"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of digital input frames from an ONIX breakout board.")]
     public class BreakoutDigitalInput : Source<BreakoutDigitalInputDataFrame>

--- a/OpenEphys.Onix1/BreakoutDigitalInput.cs
+++ b/OpenEphys.Onix1/BreakoutDigitalInput.cs
@@ -10,8 +10,8 @@ namespace OpenEphys.Onix1
     /// Produces a sequence of digital input data from an ONIX breakout board.
     /// </summary>
     /// <remarks>
-    /// This data stream operator must be linked to an appropriate configuration, such as a
-    /// <see cref="ConfigureBreakoutDigitalIO"/>, in order to stream data.
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureBreakoutDigitalIO"/>, using a shared <see cref="DeviceName"/>.
     /// </remarks>
     [Description("Produces a sequence of digital input frames from an ONIX breakout board.")]
     public class BreakoutDigitalInput : Source<BreakoutDigitalInputDataFrame>

--- a/OpenEphys.Onix1/BreakoutDigitalOutput.cs
+++ b/OpenEphys.Onix1/BreakoutDigitalOutput.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureBreakoutDigitalIO"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureBreakoutDigitalIO"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Sends digital output data to an ONIX breakout board.")]
     public class BreakoutDigitalOutput : Sink<BreakoutDigitalPortState>

--- a/OpenEphys.Onix1/BreakoutDigitalOutput.cs
+++ b/OpenEphys.Onix1/BreakoutDigitalOutput.cs
@@ -9,6 +9,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Sends digital output data to an ONIX breakout board.
     /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureBreakoutDigitalIO"/>, using a shared <see cref="DeviceName"/>.
+    /// </remarks>
     [Description("Sends digital output data to an ONIX breakout board.")]
     public class BreakoutDigitalOutput : Sink<BreakoutDigitalPortState>
     {

--- a/OpenEphys.Onix1/ConfigureBno055.cs
+++ b/OpenEphys.Onix1/ConfigureBno055.cs
@@ -5,10 +5,10 @@ namespace OpenEphys.Onix1
 {
     /// <summary>
     /// Configures a Bosch Bno055 9-axis inertial measurement unit (IMU).
-    /// </summary>C
+    /// </summary>
     /// <remarks>
-    /// This configuration operator can be linked to a <see cref="Bno055Data"/> instance to stream
-    /// orientation data from the IMU.
+    /// This configuration operator can be linked to a data IO operator, such as <see cref="Bno055Data"/>,
+    /// using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
     /// </remarks>
     [Description("Configures a Bosch Bno055 9-axis inertial measurement unit.")]
     [Editor("OpenEphys.Onix1.Design.Bno055Editor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]

--- a/OpenEphys.Onix1/ConfigureBno055.cs
+++ b/OpenEphys.Onix1/ConfigureBno055.cs
@@ -8,7 +8,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to a data IO operator, such as <see cref="Bno055Data"/>,
-    /// using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Configures a Bosch Bno055 9-axis inertial measurement unit.")]
     [Editor("OpenEphys.Onix1.Design.Bno055Editor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]

--- a/OpenEphys.Onix1/ConfigureBreakoutAnalogIO.cs
+++ b/OpenEphys.Onix1/ConfigureBreakoutAnalogIO.cs
@@ -7,6 +7,11 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Configures the ONIX breakout board's analog inputs and outputs.
     /// </summary>
+    /// <remarks>
+    /// This configuration operator can be linked to data IO operators, such as <see
+    /// cref="BreakoutAnalogInput"/> and <see cref="BreakoutAnalogOutput"/>, using a shared <see
+    /// cref="SingleDeviceFactory.DeviceName"/>.
+    /// </remarks>
     [TypeConverter(typeof(SortedPropertyConverter))]
     [Description("Configures the ONIX breakout board's analog inputs and outputs.")]
     public class ConfigureBreakoutAnalogIO : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureBreakoutAnalogIO.cs
+++ b/OpenEphys.Onix1/ConfigureBreakoutAnalogIO.cs
@@ -9,8 +9,8 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to data IO operators, such as <see
-    /// cref="BreakoutAnalogInput"/> and <see cref="BreakoutAnalogOutput"/>, using a shared <see
-    /// cref="SingleDeviceFactory.DeviceName"/>.
+    /// cref="BreakoutAnalogInput"/> and <see cref="BreakoutAnalogOutput"/>, using a shared
+    /// <c>DeviceName</c>.
     /// </remarks>
     [TypeConverter(typeof(SortedPropertyConverter))]
     [Description("Configures the ONIX breakout board's analog inputs and outputs.")]

--- a/OpenEphys.Onix1/ConfigureBreakoutDigitalIO.cs
+++ b/OpenEphys.Onix1/ConfigureBreakoutDigitalIO.cs
@@ -8,8 +8,8 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to data IO operators, such as <see
-    /// cref="BreakoutDigitalInput"/> and <see cref="BreakoutDigitalOutput"/>, using a shared <see
-    /// cref="SingleDeviceFactory.DeviceName"/>.
+    /// cref="BreakoutDigitalInput"/> and <see cref="BreakoutDigitalOutput"/>, using a shared
+    /// <c>DeviceName</c>.
     /// </remarks>
     [Description("onfigures the ONIX breakout board's digital inputs and outputs.")]
     public class ConfigureBreakoutDigitalIO : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureBreakoutDigitalIO.cs
+++ b/OpenEphys.Onix1/ConfigureBreakoutDigitalIO.cs
@@ -6,6 +6,11 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Configures the ONIX breakout board's digital inputs and outputs.
     /// </summary>
+    /// <remarks>
+    /// This configuration operator can be linked to data IO operators, such as <see
+    /// cref="BreakoutDigitalInput"/> and <see cref="BreakoutDigitalOutput"/>, using a shared <see
+    /// cref="SingleDeviceFactory.DeviceName"/>.
+    /// </remarks>
     [Description("onfigures the ONIX breakout board's digital inputs and outputs.")]
     public class ConfigureBreakoutDigitalIO : SingleDeviceFactory
     {

--- a/OpenEphys.Onix1/ConfigureHarpSyncInput.cs
+++ b/OpenEphys.Onix1/ConfigureHarpSyncInput.cs
@@ -9,6 +9,10 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// <para>
+    /// This configuration operator can be linked to a data IO operator, such as <see
+    /// cref="HarpSyncInput"/> , using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// </para>
+    /// <para>
     /// Harp is a standard for asynchronous real-time data acquisition and experimental
     /// control in neuroscience. It includes a clock synchronization protocol which allows
     /// Harp devices to be connected to a shared clock line and continuously self-synchronize

--- a/OpenEphys.Onix1/ConfigureHarpSyncInput.cs
+++ b/OpenEphys.Onix1/ConfigureHarpSyncInput.cs
@@ -10,7 +10,7 @@ namespace OpenEphys.Onix1
     /// <remarks>
     /// <para>
     /// This configuration operator can be linked to a data IO operator, such as <see
-    /// cref="HarpSyncInput"/> , using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// cref="HarpSyncInput"/>, using a shared <c>DeviceName</c>.
     /// </para>
     /// <para>
     /// Harp is a standard for asynchronous real-time data acquisition and experimental

--- a/OpenEphys.Onix1/ConfigureHeadstage64ElectricalStimulator.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64ElectricalStimulator.cs
@@ -7,9 +7,9 @@ namespace OpenEphys.Onix1
     /// Configures a headstage-64 onboard electrical stimulator.
     /// </summary>
     /// <remarks>
-    /// This configuration operator can be linked to a trigger operator, such as <see
-    /// cref="Headstage64ElectricalStimulatorTrigger"/>, using a shared <see
-    /// cref="SingleDeviceFactory.DeviceName"/>.
+    /// This configuration operator can be linked to a data IO operator, such as <see
+    /// cref="Headstage64ElectricalStimulatorTrigger"/>, using a shared
+    /// <c>DeviceName</c>.
     /// </remarks>
     [Description("Configures a headstage-64 onboard electrical stimulator.")]
     public class ConfigureHeadstage64ElectricalStimulator : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureHeadstage64ElectricalStimulator.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64ElectricalStimulator.cs
@@ -7,10 +7,9 @@ namespace OpenEphys.Onix1
     /// Configures a headstage-64 onboard electrical stimulator.
     /// </summary>
     /// <remarks>
-    /// This configuration operator can be linked to a <see cref="Headstage64ElectricalStimulatorTrigger"/>
-    /// instance to deliver current controlled electrical micro-stimulation through a contact on the probe
-    /// connector on the bottom of the headstage or the corresponding contact on a compatible electrode
-    /// interface board.
+    /// This configuration operator can be linked to a trigger operator, such as <see
+    /// cref="Headstage64ElectricalStimulatorTrigger"/>, using a shared <see
+    /// cref="SingleDeviceFactory.DeviceName"/>.
     /// </remarks>
     [Description("Configures a headstage-64 onboard electrical stimulator.")]
     public class ConfigureHeadstage64ElectricalStimulator : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
@@ -7,9 +7,9 @@ namespace OpenEphys.Onix1
     /// Configures a headstage-64 dual-channel optical stimulator.
     /// </summary>
     /// <remarks>
-    /// This configuration class can be linked to a <see cref="Headstage64OpticalStimulatorTrigger"/> instance
-    /// to drive current through laser diodes or LEDs connected to two contacts on the probe connector on the
-    /// bottom of the headstage or the corresponding contacts on a compatible electrode interface board.
+    /// This configuration operator can be linked to a trigger operator, such as <see
+    /// cref="Headstage64OpticalStimulatorTrigger"/>, using a shared <see
+    /// cref="SingleDeviceFactory.DeviceName"/>.
     /// </remarks>
     [Description("Configures a headstage-64 dual-channel optical stimulator.")]
     public class ConfigureHeadstage64OpticalStimulator : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
+++ b/OpenEphys.Onix1/ConfigureHeadstage64OpticalStimulator.cs
@@ -7,9 +7,9 @@ namespace OpenEphys.Onix1
     /// Configures a headstage-64 dual-channel optical stimulator.
     /// </summary>
     /// <remarks>
-    /// This configuration operator can be linked to a trigger operator, such as <see
-    /// cref="Headstage64OpticalStimulatorTrigger"/>, using a shared <see
-    /// cref="SingleDeviceFactory.DeviceName"/>.
+    /// This configuration operator can be linked to a data IO operator, such as <see
+    /// cref="Headstage64OpticalStimulatorTrigger"/>, using a shared
+    /// <c>DeviceName</c>.
     /// </remarks>
     [Description("Configures a headstage-64 dual-channel optical stimulator.")]
     public class ConfigureHeadstage64OpticalStimulator : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureHeartbeat.cs
+++ b/OpenEphys.Onix1/ConfigureHeartbeat.cs
@@ -8,11 +8,11 @@ namespace OpenEphys.Onix1
 {
     /// <summary>
     /// Configures a heartbeat device.
-    /// <remarks>
-    /// This configuration operator can be linked to a <see cref="HeartbeatData"/> instance to stream
-    /// heartbeats from the acquisition system.
-    /// </remarks>
     /// </summary>
+    /// <remarks>
+    /// This configuration operator can be linked to a data IO operator, such as <see cref="HeartbeatData"/>,
+    /// using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// </remarks>
     [Description("Configures a heartbeat device.")]
     public class ConfigureHeartbeat : SingleDeviceFactory
     {

--- a/OpenEphys.Onix1/ConfigureHeartbeat.cs
+++ b/OpenEphys.Onix1/ConfigureHeartbeat.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to a data IO operator, such as <see cref="HeartbeatData"/>,
-    /// using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Configures a heartbeat device.")]
     public class ConfigureHeartbeat : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureLoadTester.cs
+++ b/OpenEphys.Onix1/ConfigureLoadTester.cs
@@ -7,12 +7,13 @@ using Bonsai;
 
 namespace OpenEphys.Onix1
 {
+    // TODO: Add data IO operators, update XML comment to link to them (<see cref="LoadTesterData"/>)
     /// <summary>
     /// Configures a load tester device.
     /// </summary>
     /// <remarks>
-    /// This configuration operator can be linked to a data IO operator, such as <see cref="LoadTesterData"/>,
-    /// using a shared <see cref="SingleDeviceFactory.DeviceName"/>. The load tester device can be configured
+    /// This configuration operator can be linked to a data IO operator, such as LoadTesterData,
+    /// using a shared <c>DeviceName</c>. The load tester device can be configured
     /// to produce data at user-settable size and rate to stress test various communication links and test
     /// closed-loop response latency.
     /// </remarks>

--- a/OpenEphys.Onix1/ConfigureLoadTester.cs
+++ b/OpenEphys.Onix1/ConfigureLoadTester.cs
@@ -11,8 +11,10 @@ namespace OpenEphys.Onix1
     /// Configures a load tester device.
     /// </summary>
     /// <remarks>
-    /// The load tester device can be configured to produce data at user-settable size and rate
-    /// to stress test various communication links and test closed-loop response latency.
+    /// This configuration operator can be linked to a data IO operator, such as <see cref="LoadTesterData"/>,
+    /// using a shared <see cref="SingleDeviceFactory.DeviceName"/>. The load tester device can be configured
+    /// to produce data at user-settable size and rate to stress test various communication links and test
+    /// closed-loop response latency.
     /// </remarks>
     [Description("Configures a load testing device.")]
     public class ConfigureLoadTester : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureMemoryMonitor.cs
+++ b/OpenEphys.Onix1/ConfigureMemoryMonitor.cs
@@ -9,7 +9,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to a data IO operator, such as <see
-    /// cref="MemoryMonitorData"/>, using a shared <see cref="SingleDeviceFactory.DeviceName"/>.The memory
+    /// cref="MemoryMonitorData"/>, using a shared <c>DeviceName</c>.The memory
     /// monitor produces periodic snapshots of the system's first in, first out (FIFO) data buffer. This can
     /// be useful for:
     /// <list type="bullet">

--- a/OpenEphys.Onix1/ConfigureMemoryMonitor.cs
+++ b/OpenEphys.Onix1/ConfigureMemoryMonitor.cs
@@ -8,19 +8,24 @@ namespace OpenEphys.Onix1
     /// Configures a hardware memory monitor.
     /// </summary>
     /// <remarks>
-    /// The memory monitor produces periodic snapshots of the system's first in, first out (FIFO) data buffer.
-    /// This can be useful for:
+    /// This configuration operator can be linked to a data IO operator, such as <see
+    /// cref="MemoryMonitorData"/>, using a shared <see cref="SingleDeviceFactory.DeviceName"/>.The memory
+    /// monitor produces periodic snapshots of the system's first in, first out (FIFO) data buffer. This can
+    /// be useful for:
     /// <list type="bullet">
     /// <item>
-    /// <description>Ensuring that data is being read by the host PC quickly enough to prevent real-time delays or overflows.
-    /// In the case that the PC is not keeping up with data collection, FIFO memory use will increase monotonically.</description>
+    /// <description>Ensuring that data is being read by the host PC quickly enough to prevent real-time
+    /// delays or overflows. In the case that the PC is not keeping up with data collection, FIFO memory use
+    /// will increase monotonically.</description>
     /// </item>
     /// <item>
-    /// <description>Tuning the value of <see cref="StartAcquisition.ReadSize"/> to optimize real-time performance.
-    /// For optimal real-time performance, <see cref="StartAcquisition.ReadSize"/> should be as small as possible and the FIFO should be bypassed
-    /// (memory usage should remain at 0). However, these requirements are in conflict. The memory monitor provides a way to find the minimal value of
-    /// value of <see cref="StartAcquisition.ReadSize"/> that does not result in excessive FIFO data buffering. This tradeoff will depend on the
-    /// bandwidth of data being acquired, the performance of the host PC, and downstream real-time processing.</description>
+    /// <description>Tuning the value of <see cref="StartAcquisition.ReadSize"/> to optimize real-time
+    /// performance. For optimal real-time performance, <see cref="StartAcquisition.ReadSize"/> should be as
+    /// small as possible and the FIFO should be bypassed (memory usage should remain at 0). However, these
+    /// requirements are in conflict. The memory monitor provides a way to find the minimal value of value of
+    /// <see cref="StartAcquisition.ReadSize"/> that does not result in excessive FIFO data buffering. This
+    /// tradeoff will depend on the bandwidth of data being acquired, the performance of the host PC, and
+    /// downstream real-time processing.</description>
     /// </item>
     /// </list>
     /// </remarks>

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
@@ -9,6 +9,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Configures a NeuropixelsV1e device.
     /// </summary>
+    /// <remarks>
+    /// This configuration operator can be linked to a data IO operator, such as <see cref="NeuropixelsV1eData"/>,
+    /// using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// </remarks>
     [Description("Configures a NeuropixelsV1e device.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV1eEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
     public class ConfigureNeuropixelsV1e : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1e.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to a data IO operator, such as <see cref="NeuropixelsV1eData"/>,
-    /// using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Configures a NeuropixelsV1e device.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV1eEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1eBno055.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1eBno055.cs
@@ -6,6 +6,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Configures a NeuropixelsV1eBno055 device.
     /// </summary>
+    /// <remarks>
+    /// This configuration operator can be linked to a data IO operator, such as <see
+    /// cref="NeuropixelsV1eBno055Data"/>, using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// </remarks>
     [Description("Configures a NeuropixelsV1eBno055 device.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV1eBno055Editor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
     public class ConfigureNeuropixelsV1eBno055 : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV1eBno055.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV1eBno055.cs
@@ -8,7 +8,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to a data IO operator, such as <see
-    /// cref="NeuropixelsV1eBno055Data"/>, using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// cref="NeuropixelsV1eBno055Data"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Configures a NeuropixelsV1eBno055 device.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV1eBno055Editor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -293,7 +293,7 @@ namespace OpenEphys.Onix1
         public const byte ProbeBSelected = 0b1001_1001;
 
         public const int FramesPerSuperFrame = 16;
-        public const int ADCsPerProbe = 24;
+        public const int AdcsPerProbe = 24;
         public const int ChannelCount = 384;
         public const int FrameWords = 36; // TRASH TRASH TRASH 0 ADC0 ADC8 ADC16 0 ADC1 ADC9 ADC17 0 ... ADC7 ADC15 ADC23 0
 

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to a data IO operator, such as <see
-    /// cref="NeuropixelsV2eData"/>, using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// cref="NeuropixelsV2eData"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Configures a NeuropixelsV2eBeta device.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -9,6 +9,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Configures a NeuropixelsV2eBeta device.
     /// </summary>
+    /// <remarks>
+    /// This configuration operator can be linked to a data IO operator, such as <see
+    /// cref="NeuropixelsV2eData"/>, using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// </remarks>
     [Description("Configures a NeuropixelsV2eBeta device.")]
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eEditor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
     public class ConfigureNeuropixelsV2eBeta : SingleDeviceFactory, IConfigureNeuropixelsV2

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBno055.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBno055.cs
@@ -6,6 +6,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Configures a NeuropixelsV2eBno055 device.
     /// </summary>
+    /// <remarks>
+    /// This configuration operator can be linked to a data IO operator, such as <see
+    /// cref="NeuropixelsV2eBno055Data"/>, using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// </remarks>
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eBno055Editor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
     [Description("Configures a NeuropixelsV2eBno055 device.")]
     public class ConfigureNeuropixelsV2eBno055 : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBno055.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBno055.cs
@@ -8,7 +8,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to a data IO operator, such as <see
-    /// cref="NeuropixelsV2eBno055Data"/>, using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// cref="NeuropixelsV2eBno055Data"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Editor("OpenEphys.Onix1.Design.NeuropixelsV2eBno055Editor, OpenEphys.Onix1.Design", typeof(ComponentEditor))]
     [Description("Configures a NeuropixelsV2eBno055 device.")]

--- a/OpenEphys.Onix1/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix1/ConfigureRhd2164.cs
@@ -8,7 +8,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to a data IO operator, such as <see
-    /// cref="Rhd2164Data"/>, using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
+    /// cref="Rhd2164Data"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Configures a Rhd2164 device.")]
     public class ConfigureRhd2164 : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix1/ConfigureRhd2164.cs
@@ -7,8 +7,8 @@ namespace OpenEphys.Onix1
     /// Configures an Intan Rhd2164 bioamplifier chip.
     /// </summary>
     /// <remarks>
-    /// This configuration operator can be linked to a <see cref="Rhd2164Data"/> instance to stream
-    /// electrophysiology data from the chip.
+    /// This configuration operator can be linked to a data IO operator, such as <see
+    /// cref="Rhd2164Data"/>, using a shared <see cref="SingleDeviceFactory.DeviceName"/>.
     /// </remarks>
     [Description("Configures a Rhd2164 device.")]
     public class ConfigureRhd2164 : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureTS4231V1.cs
+++ b/OpenEphys.Onix1/ConfigureTS4231V1.cs
@@ -8,8 +8,10 @@ namespace OpenEphys.Onix1
     /// a pair of SteamVR V1 base stations.
     /// </summary>
     /// <remarks>
-    /// This configuration operator can be linked to a <see cref="TS4231V1PositionData"/> instance to stream 3D position data from
-    /// light-house receivers when SteamVR V1 base stations have been installed above the arena.
+    /// This configuration operator can be linked to a data IO operator, such as <see
+    /// cref="TS4231V1PositionData"/> using a shared <see cref="SingleDeviceFactory.DeviceName"/> to stream 3D
+    /// position data from light-house receivers when SteamVR V1 base stations have been installed above the
+    /// arena.
     /// </remarks>
     [Description("Configures a TS4231 receiver array.")]
     public class ConfigureTS4231V1 : SingleDeviceFactory

--- a/OpenEphys.Onix1/ConfigureTS4231V1.cs
+++ b/OpenEphys.Onix1/ConfigureTS4231V1.cs
@@ -9,7 +9,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to a data IO operator, such as <see
-    /// cref="TS4231V1PositionData"/> using a shared <see cref="SingleDeviceFactory.DeviceName"/> to stream 3D
+    /// cref="TS4231V1PositionData"/>, using a shared <c>DeviceName</c> to stream 3D
     /// position data from light-house receivers when SteamVR V1 base stations have been installed above the
     /// arena.
     /// </remarks>

--- a/OpenEphys.Onix1/DeviceFactory.cs
+++ b/OpenEphys.Onix1/DeviceFactory.cs
@@ -47,7 +47,7 @@ namespace OpenEphys.Onix1
         /// <remarks>
         /// The device name provides a unique, human-readable identifier that is used to link software
         /// elements for configuration, control, and data streaming to hardware. For instance, it can be used
-        /// to link configuration operators to data streaming operators within a workflow.This value is
+        /// to link configuration operators to data IO operators within a workflow. This value is
         /// usually not set manually, but is assigned in a <see cref="MultiDeviceFactory"/> to correspond to a
         /// fixed address with a piece of hardware such as a headstage. This address is used for software
         /// communication.

--- a/OpenEphys.Onix1/DeviceFactory.cs
+++ b/OpenEphys.Onix1/DeviceFactory.cs
@@ -23,14 +23,13 @@ namespace OpenEphys.Onix1
     }
 
     /// <summary>
-    /// Provides an abstract base class for configuration operators responsible for
-    /// registering a single device within the internal device manager.
+    /// Abstract base for configuration operators responsible for registering a single device within the
+    /// internal device manager.
     /// </summary>
     /// <remarks>
-    /// ONI devices usually require a specific sequence of configuration and parameterization
-    /// steps before they can be interacted with. The <see cref="SingleDeviceFactory"/>
-    /// provides a modular abstraction allowing flexible assembly and sequencing of
-    /// of all device-specific configuration code.
+    /// ONI devices usually require a specific sequence of configuration and parameterization steps before
+    /// they can be interacted with. The <see cref="SingleDeviceFactory"/> provides a modular abstraction
+    /// allowing flexible assembly and sequencing of of all device-specific configuration code.
     /// </remarks>
     public abstract class SingleDeviceFactory : DeviceFactory, IDeviceConfiguration
     {
@@ -47,9 +46,11 @@ namespace OpenEphys.Onix1
         /// </summary>
         /// <remarks>
         /// The device name provides a unique, human-readable identifier that is used to link software
-        /// elements for configuration, control, and data streaming to hardware. This is often a one-to-one
-        /// representation of a single <see cref="oni.Device"/>, but can also represent abstract ONI device
-        /// aggregates or virtual devices.
+        /// elements for configuration, control, and data streaming to hardware. For instance, it can be used
+        /// to link configuration operators to data streaming operators within a workflow.This value is
+        /// usually not set manually, but is assigned in a <see cref="MultiDeviceFactory"/> to correspond to a
+        /// fixed address with a piece of hardware such as a headstage. This address is used for software
+        /// communication.
         /// </remarks>
         [Description(DeviceNameDescription)]
         [Category(ConfigurationCategory)]
@@ -59,8 +60,11 @@ namespace OpenEphys.Onix1
         /// Gets or sets the device address.
         /// </summary>
         /// <remarks>
-        /// This address provides a fully-qualified location of a device within the device table. This is often a one-to-one
-        /// representation of a <see cref="oni.Device.Address"/>, but can also represent abstract device addresses.
+        /// This is a fully-qualified numerical hardware address of a device within the device table produced
+        /// by an <see href="https://open-ephys.github.io/ONI/">Open Neuro Interface (ONI)</see> compliant
+        /// acquisition system. This value is usually not set manually, but is assigned in a <see
+        /// cref="MultiDeviceFactory"/> to correspond to a fixed address with a piece of hardware such as a
+        /// headstage. This address is used for hardware communication.
         /// </remarks>
         [Description(DeviceAddressDescription)]
         [Category(ConfigurationCategory)]
@@ -70,8 +74,9 @@ namespace OpenEphys.Onix1
         /// Gets or sets the device identity.
         /// </summary>
         /// <remarks>
-        /// This type provides a device identity to each device within the device table. This is often a one-to-one
-        /// representation of a a <see cref="oni.Device.ID"/>, but can also represent abstract device identities.
+        /// This type provides a device identity to each device within the device table produced by an <see
+        /// href="https://open-ephys.github.io/ONI/">Open Neuro Interface (ONI)</see> compliant acquisition
+        /// system.
         /// </remarks>
         [Browsable(false)]
         public Type DeviceType { get; }

--- a/OpenEphys.Onix1/HarpSyncInputData.cs
+++ b/OpenEphys.Onix1/HarpSyncInputData.cs
@@ -7,7 +7,8 @@ using Bonsai;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Produces a sequence of Harp clock synchronization signals sent to the Harp input in the ONIX breakout board.
+    /// Produces a sequence of Harp clock synchronization signals sent to the Harp input in the ONIX breakout
+    /// board.
     /// </summary>
     /// <inheritdoc cref = "ConfigureHarpSyncInput"/>
     [Description("Produces a sequence of Harp clock synchronization signals sent to the Harp input in the ONIX breakout board.")]

--- a/OpenEphys.Onix1/Headstage64ElectricalStimulatorTrigger.cs
+++ b/OpenEphys.Onix1/Headstage64ElectricalStimulatorTrigger.cs
@@ -14,8 +14,8 @@ namespace OpenEphys.Onix1
     /// Controls a headstage-64 onboard electrical stimulus sequencer.
     /// </summary>
     /// <remarks>
-    /// This trigger operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureHeadstage64ElectricalStimulator"/>, using a shared <see cref="DeviceName"/>.
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureHeadstage64ElectricalStimulator"/>, using a shared <c>DeviceName</c>.
     /// Headstage-64's onboard electrical stimulator can be used to deliver current controlled
     /// micro-stimulation through a contact on the probe connector on the bottom of the headstage or the
     /// corresponding contact on a compatible electrode interface board.

--- a/OpenEphys.Onix1/Headstage64ElectricalStimulatorTrigger.cs
+++ b/OpenEphys.Onix1/Headstage64ElectricalStimulatorTrigger.cs
@@ -14,8 +14,11 @@ namespace OpenEphys.Onix1
     /// Controls a headstage-64 onboard electrical stimulus sequencer.
     /// </summary>
     /// <remarks>
-    /// This operator must be linked to an appropriate configuration, such as a <see cref="ConfigureHeadstage64ElectricalStimulator"/>,
-    /// in order to define and deliver electrical stimulation sequences.
+    /// This trigger operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureHeadstage64ElectricalStimulator"/>, using a shared <see cref="DeviceName"/>.
+    /// Headstage-64's onboard electrical stimulator can be used to deliver current controlled
+    /// micro-stimulation through a contact on the probe connector on the bottom of the headstage or the
+    /// corresponding contact on a compatible electrode interface board.
     /// </remarks>
     [Description("Controls a headstage-64 onboard electrical stimulus sequencer.")]
     public class Headstage64ElectricalStimulatorTrigger: Sink<bool>

--- a/OpenEphys.Onix1/Headstage64OpticalStimulatorTrigger.cs
+++ b/OpenEphys.Onix1/Headstage64OpticalStimulatorTrigger.cs
@@ -14,8 +14,11 @@ namespace OpenEphys.Onix1
     /// Controls a headstage-64 onboard optical stimulus sequencer.
     /// </summary>
     /// <remarks>
-    /// This operator must be linked to an appropriate configuration, such as a <see cref="ConfigureHeadstage64OpticalStimulator"/>,
-    /// in order to define and deliver optical stimulation sequences.
+    /// This trigger operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureHeadstage64OpticalStimulator"/>, using a shared <see cref="DeviceName"/>.
+    /// Headstage-64's onboard optical stimulator can be used to drive current through laser diodes or LEDs
+    /// connected to two contacts on the probe connector on the bottom of the headstage or the corresponding
+    /// contacts on a compatible electrode interface board.
     /// </remarks>
     [Description("Controls a headstage-64 onboard optical stimulus sequencer.")]
     public class Headstage64OpticalStimulatorTrigger : Sink<bool>

--- a/OpenEphys.Onix1/Headstage64OpticalStimulatorTrigger.cs
+++ b/OpenEphys.Onix1/Headstage64OpticalStimulatorTrigger.cs
@@ -14,8 +14,8 @@ namespace OpenEphys.Onix1
     /// Controls a headstage-64 onboard optical stimulus sequencer.
     /// </summary>
     /// <remarks>
-    /// This trigger operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureHeadstage64OpticalStimulator"/>, using a shared <see cref="DeviceName"/>.
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureHeadstage64OpticalStimulator"/>, using a shared <c>DeviceName</c>.
     /// Headstage-64's onboard optical stimulator can be used to drive current through laser diodes or LEDs
     /// connected to two contacts on the probe connector on the bottom of the headstage or the corresponding
     /// contacts on a compatible electrode interface board.

--- a/OpenEphys.Onix1/HeartbeatData.cs
+++ b/OpenEphys.Onix1/HeartbeatData.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureHeartbeat"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureHeartbeat"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of heartbeat data frames.")]
     public class HeartbeatData : Source<HeartbeatDataFrame>

--- a/OpenEphys.Onix1/HeartbeatData.cs
+++ b/OpenEphys.Onix1/HeartbeatData.cs
@@ -10,8 +10,8 @@ namespace OpenEphys.Onix1
     /// Produces a sequence of heartbeat data frames.
     /// </summary>
     /// <remarks>
-    /// This data stream class must be linked to an appropriate configuration, such as a <see cref="ConfigureHeartbeat"/>,
-    /// in order to stream heartbeat data.
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureHeartbeat"/>, using a shared <see cref="DeviceName"/>.
     /// </remarks>
     [Description("Produces a sequence of heartbeat data frames.")]
     public class HeartbeatData : Source<HeartbeatDataFrame>

--- a/OpenEphys.Onix1/MemoryMonitorData.cs
+++ b/OpenEphys.Onix1/MemoryMonitorData.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureMemoryMonitor"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureMemoryMonitor"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of memory usage data frames.")]
     public class MemoryMonitorData : Source<MemoryMonitorDataFrame>

--- a/OpenEphys.Onix1/MemoryMonitorData.cs
+++ b/OpenEphys.Onix1/MemoryMonitorData.cs
@@ -10,8 +10,8 @@ namespace OpenEphys.Onix1
     /// Produces a sequence of memory usage data frames.
     /// </summary>
     /// <remarks>
-    /// This data stream operator must be linked to an appropriate configuration, such as a <see cref="ConfigureMemoryMonitor"/>,
-    /// in order to stream data.
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureMemoryMonitor"/>, using a shared <see cref="DeviceName"/>.
     /// </remarks>
     [Description("Produces a sequence of memory usage data frames.")]
     public class MemoryMonitorData : Source<MemoryMonitorDataFrame>

--- a/OpenEphys.Onix1/MultiDeviceFactory.cs
+++ b/OpenEphys.Onix1/MultiDeviceFactory.cs
@@ -42,8 +42,8 @@ namespace OpenEphys.Onix1
         /// Gets or sets a unique device group name.
         /// </summary>
         /// <remarks>
-        /// A human-readable identifier that is used as a prefix for 
-        /// the <see cref="SingleDeviceFactory.DeviceName"/> of each device in the the group. 
+        /// A human-readable identifier that is used as a prefix for the <see
+        /// cref="SingleDeviceFactory.DeviceName"/> of each device in the the group. 
         /// </remarks>
         [Description("The unique device group name.")]
         [Category(ConfigurationCategory)]

--- a/OpenEphys.Onix1/NeuropixelsV1eBno055Data.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eBno055Data.cs
@@ -9,6 +9,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Produces a sequence of <see cref="Bno055DataFrame"/> objects from a NeuropixelsV1e headstage.
     /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureNeuropixelsV1eBno055"/>, using a shared <see cref="DeviceName"/>.
+    /// </remarks>
     [Description("Produces a sequence of Bno055DataFrame objects from a NeuropixelsV1e headstage.")]
     public class NeuropixelsV1eBno055Data : Source<Bno055DataFrame>
     {

--- a/OpenEphys.Onix1/NeuropixelsV1eBno055Data.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eBno055Data.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureNeuropixelsV1eBno055"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureNeuropixelsV1eBno055"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of Bno055DataFrame objects from a NeuropixelsV1e headstage.")]
     public class NeuropixelsV1eBno055Data : Source<Bno055DataFrame>

--- a/OpenEphys.Onix1/NeuropixelsV1eData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eData.cs
@@ -11,6 +11,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Produces a sequence of <see cref="NeuropixelsV1eDataFrame"/>s from a NeuropixelsV1e headstage.
     /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureNeuropixelsV1e"/>, using a shared <see cref="DeviceName"/>.
+    /// </remarks>
     [Description("Produces a sequence of NeuropixelsV1eDataFrame objects from a NeuropixelsV1e headstage.")]
     public class NeuropixelsV1eData : Source<NeuropixelsV1eDataFrame>
     {

--- a/OpenEphys.Onix1/NeuropixelsV1eData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eData.cs
@@ -13,7 +13,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureNeuropixelsV1e"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureNeuropixelsV1e"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of NeuropixelsV1eDataFrame objects from a NeuropixelsV1e headstage.")]
     public class NeuropixelsV1eData : Source<NeuropixelsV1eDataFrame>

--- a/OpenEphys.Onix1/NeuropixelsV2eBetaData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBetaData.cs
@@ -13,7 +13,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureNeuropixelsV2eBeta"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureNeuropixelsV2eBeta"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of NeuropixelsV2eDataFrame objects from a NeuropixelsV2e headstage.")]
     public class NeuropixelsV2eBetaData : Source<NeuropixelsV2eBetaDataFrame>

--- a/OpenEphys.Onix1/NeuropixelsV2eBetaData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBetaData.cs
@@ -11,6 +11,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Produces a sequence of <see cref="NeuropixelsV2eBetaDataFrame"/> objects from a NeuropixelsV2eBeta headstage.
     /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureNeuropixelsV2eBeta"/>, using a shared <see cref="DeviceName"/>.
+    /// </remarks>
     [Description("Produces a sequence of NeuropixelsV2eDataFrame objects from a NeuropixelsV2e headstage.")]
     public class NeuropixelsV2eBetaData : Source<NeuropixelsV2eBetaDataFrame>
     {

--- a/OpenEphys.Onix1/NeuropixelsV2eBno055Data.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBno055Data.cs
@@ -9,6 +9,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Produces a sequence of <see cref="Bno055DataFrame"/> objects from a NeuropixelsV2e headstage.
     /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureNeuropixelsV2eBno055"/>, using a shared <see cref="DeviceName"/>.
+    /// </remarks>
     [Description("Produces a sequence of Bno055DataFrame objects from a NeuropixelsV2e headstage.")]
     public class NeuropixelsV2eBno055Data : Source<Bno055DataFrame>
     {

--- a/OpenEphys.Onix1/NeuropixelsV2eBno055Data.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eBno055Data.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureNeuropixelsV2eBno055"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureNeuropixelsV2eBno055"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of Bno055DataFrame objects from a NeuropixelsV2e headstage.")]
     public class NeuropixelsV2eBno055Data : Source<Bno055DataFrame>

--- a/OpenEphys.Onix1/NeuropixelsV2eData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eData.cs
@@ -11,6 +11,10 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Produces a sequence of <see cref="NeuropixelsV2eDataFrame"/> objects from a NeuropixelsV2e headstage.
     /// </summary>
+    /// <remarks>
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureNeuropixelsV2e"/>, using a shared <see cref="DeviceName"/>.
+    /// </remarks>
     [Description("Produces a sequence of NeuropixelsV2eDataFrame objects from a NeuropixelsV2e headstage.")]
     public class NeuropixelsV2eData : Source<NeuropixelsV2eDataFrame>
     {
@@ -24,12 +28,13 @@ namespace OpenEphys.Onix1
         /// Gets or sets the buffer size.
         /// </summary>
         /// <remarks>
-        /// This property determines the number of super-frames that are buffered before data is propagated. A super-frame consists of 384 
-        /// channels from the spike-band and 32 channels from the LFP band. If this value is set to 30, then 30 super-frames, along with 
-        /// corresponding clock values, will be collected and packed into each <see cref="NeuropixelsV2eDataFrame"/>. Because channels are 
-        /// sampled at 30 kHz, this is equivalent to 1 millisecond of data from each channel.
+        /// This property determines the number of samples that are collected from each of the 384 ephys
+        /// channels before data is propagated. For instance, if this value is set to 30, then 384x30 samples,
+        /// along with 30 corresponding clock values, will be collected and packed into each <see
+        /// cref="NeuropixelsV2eDataFrame"/>. Because channels are sampled at 30 kHz, this is equivalent to 1
+        /// millisecond of data from each channel.
         /// </remarks>
-        [Description("The number of samples collected for each channel that are used to create a single NeuropixelsV2eDataFrame.")]
+        [Description("The number of samples collected from each channel that are used to create a single NeuropixelsV2eDataFrame.")]
         [Category(DeviceFactory.ConfigurationCategory)]
         public int BufferSize { get; set; } = 30;
 
@@ -41,9 +46,9 @@ namespace OpenEphys.Onix1
         public NeuropixelsV2Probe ProbeIndex { get; set; }
 
         /// <summary>
-        /// Generates a sequence of <see cref="NeuropixelsV2eDataFrame"/> objects.
+        /// Generates a sequence of <see cref="NeuropixelsV2eDataFrame"/>s.
         /// </summary>
-        /// <returns>A sequence of <see cref="NeuropixelsV2eDataFrame"/> objects.</returns>
+        /// <returns>A sequence of <see cref="NeuropixelsV2eDataFrame"/>s.</returns>
         public unsafe override IObservable<NeuropixelsV2eDataFrame> Generate()
         {
             var bufferSize = BufferSize;

--- a/OpenEphys.Onix1/NeuropixelsV2eData.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eData.cs
@@ -13,7 +13,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureNeuropixelsV2e"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureNeuropixelsV2e"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of NeuropixelsV2eDataFrame objects from a NeuropixelsV2e headstage.")]
     public class NeuropixelsV2eData : Source<NeuropixelsV2eDataFrame>

--- a/OpenEphys.Onix1/NeuropixelsV2eDataFrame.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2eDataFrame.cs
@@ -39,9 +39,9 @@ namespace OpenEphys.Onix1
                 // The period of ADC data within data array is 36 words
                 var adcDataOffset = i * NeuropixelsV2e.FrameWords;
 
-                for (int k = 0; k < NeuropixelsV2e.ADCsPerProbe; k++)
+                for (int k = 0; k < NeuropixelsV2e.AdcsPerProbe; k++)
                 {
-                    amplifierBuffer[RawToChannel[k, i], index] = (ushort)(gainCorrection * amplifierData[ADCIndices[k] + adcDataOffset]);
+                    amplifierBuffer[RawToChannel[k, i], index] = (ushort)(gainCorrection * amplifierData[AdcIndicies[k] + adcDataOffset]);
                 }
             }
         }
@@ -50,7 +50,7 @@ namespace OpenEphys.Onix1
         // First dimension: data index
         // Second dimension: frame index within super frame
 
-        static readonly int[] ADCIndices = {
+        static readonly int[] AdcIndicies = {
             0, 1, 2,
             4, 5, 6,
             8, 9, 10,

--- a/OpenEphys.Onix1/PortStatus.cs
+++ b/OpenEphys.Onix1/PortStatus.cs
@@ -10,9 +10,8 @@ namespace OpenEphys.Onix1
     /// Produces a sequence of port status information frames.
     /// </summary>
     /// <remarks>
-    /// This data stream operator must be linked to an appropriate headstage,
-    /// miniscope, etc. configuration whose communication is dictated by
-    /// a PortController.
+    /// This data IO operator must be linked to an appropriate headstage or miniscope configuration (e.g. <see
+    /// cref="ConfigureNeuropixelsV2eBeta"/>) using a shared <see cref="DeviceName"/>.
     /// </remarks>
     [Description("Produces a sequence of port status information.")]
     public class PortStatus : Source<PortStatusFrame>

--- a/OpenEphys.Onix1/PortStatus.cs
+++ b/OpenEphys.Onix1/PortStatus.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate headstage or miniscope configuration (e.g. <see
-    /// cref="ConfigureNeuropixelsV2eBeta"/>) using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureNeuropixelsV2eBeta"/>) using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of port status information.")]
     public class PortStatus : Source<PortStatusFrame>

--- a/OpenEphys.Onix1/Rhd2164Data.cs
+++ b/OpenEphys.Onix1/Rhd2164Data.cs
@@ -14,7 +14,7 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureRhd2164"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureRhd2164"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of electrophysiology data frames from an Intan Rhd2164 bioacquisition chip.")]
     public class Rhd2164Data : Source<Rhd2164DataFrame>

--- a/OpenEphys.Onix1/Rhd2164Data.cs
+++ b/OpenEphys.Onix1/Rhd2164Data.cs
@@ -13,8 +13,8 @@ namespace OpenEphys.Onix1
     /// Produces a sequence of electrophysiology data frames from an Intan Rhd2164 bioacquisition chip.
     /// </summary>
     /// <remarks>
-    /// This data stream operator must be linked to an appropriate configuration, such as a <see cref="ConfigureRhd2164"/>,
-    /// in order to stream electrophysiology data.
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureRhd2164"/>, using a shared <see cref="DeviceName"/>.
     /// </remarks>
     [Description("Produces a sequence of electrophysiology data frames from an Intan Rhd2164 bioacquisition chip.")]
     public class Rhd2164Data : Source<Rhd2164DataFrame>

--- a/OpenEphys.Onix1/TS4231V1Data.cs
+++ b/OpenEphys.Onix1/TS4231V1Data.cs
@@ -11,14 +11,15 @@ namespace OpenEphys.Onix1
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This data stream class must be linked to an appropriate configuration, such as a <see cref="ConfigureTS4231V1"/>,
-    /// in order to stream 3D position data.
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureTS4231V1"/>, using a shared <see cref="DeviceName"/>.
     /// </para>
     /// <para>
-    /// The data produced by this class contains individual base station pulse/sweep codes and timing information. These data provide
-    /// rapid updates that constrain the possible position of a sensor and therefore can be combined with orientation information
-    /// in a downstream predictive model (e.g. Kalman filter) for high-accuracy and robust position tracking. To produce naïve
-    /// position estimates, use the <see cref="TS4231V1PositionData"/> operator instead of this one.
+    /// The data produced by this class contains individual base station pulse/sweep codes and timing
+    /// information. These data provide rapid updates that constrain the possible position of a sensor and
+    /// therefore can be combined with orientation information in a downstream predictive model (e.g. Kalman
+    /// filter) for high-accuracy and robust position tracking. To produce naïve position estimates, use the
+    /// <see cref="TS4231V1PositionData"/> operator instead of this one.
     /// </para>
     /// </remarks>
     [Description("Produces a sequence of decoded optical signals produced by a pair of SteamVR V1 base stations.")]

--- a/OpenEphys.Onix1/TS4231V1Data.cs
+++ b/OpenEphys.Onix1/TS4231V1Data.cs
@@ -12,7 +12,7 @@ namespace OpenEphys.Onix1
     /// <remarks>
     /// <para>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureTS4231V1"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureTS4231V1"/>, using a shared <c>DeviceName</c>.
     /// </para>
     /// <para>
     /// The data produced by this class contains individual base station pulse/sweep codes and timing

--- a/OpenEphys.Onix1/TS4231V1PositionData.cs
+++ b/OpenEphys.Onix1/TS4231V1PositionData.cs
@@ -15,7 +15,7 @@ namespace OpenEphys.Onix1
     /// <remarks>
     /// <para>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureTS4231V1"/>, using a shared <see cref="DeviceName"/>.
+    /// cref="ConfigureTS4231V1"/>, using a shared <c>DeviceName</c>.
     /// </para>
     /// <para>
     /// The data produced by this class contains naïve geometric estimates of positions of photodiodes
@@ -32,7 +32,7 @@ namespace OpenEphys.Onix1
     /// are used to determine the ray from each base station to the TS3231's photodiode. A simple geometric
     /// inversion is performed to determine the photodiodes 3D position from the values <see cref="P"/> and
     /// <see cref="Q"/>. It does not use a predictive model or integrate data from an IMU and is therefore
-    /// quite sensitive to obstructions in and will require post-hoc processing to correct systematic errors
+    /// quite sensitive to obstructions and will require post-hoc processing to correct systematic errors
     /// due to optical aberrations and nonlinearities. The the <see cref="TS4231V1Data"/> operator provides
     /// access to individual lighthouse signals that is useful for a creating more robust position estimates
     /// using downstream processing.
@@ -51,8 +51,9 @@ namespace OpenEphys.Onix1
         /// Gets or sets the position of the first base station in arbitrary units.
         /// </summary>
         /// <remarks>
-        /// The units used will determine the units of <see cref="TS4231V1PositionDataFrame.Position"/> and must match those used in <see cref="Q"/>.
-        /// Typically this value is used to define the origin and remains at (0, 0, 0).
+        /// The units used will determine the units of <see cref="TS4231V1PositionDataFrame.Position"/> and
+        /// must match those used in <see cref="Q"/>. Typically this value is used to define the origin and
+        /// remains at (0, 0, 0).
         /// </remarks>
         [Description("The position of the first base station in arbitrary units.")]
         [Category(DeviceFactory.ConfigurationCategory)]
@@ -62,14 +63,16 @@ namespace OpenEphys.Onix1
         /// Gets or sets the position of the second base station in arbitrary units.
         /// </summary>
         /// <remarks>
-        /// The units used will determine the units of <see cref="TS4231V1PositionDataFrame.Position"/> and must match those used in <see cref="P"/>.
+        /// The units used will determine the units of <see cref="TS4231V1PositionDataFrame.Position"/> and
+        /// must match those used in <see cref="P"/>.
         /// </remarks>
         [Description("The position of the second base station in arbitrary units.")]
         [Category(DeviceFactory.ConfigurationCategory)]
         public Point3d Q { get; set; } = new(1, 0, 0);
 
         /// <summary>
-        /// Generates a sequence of <see cref="TS4231V1PositionDataFrame"/> objects, each of which contains the 3D position of single photodiode.
+        /// Generates a sequence of <see cref="TS4231V1PositionDataFrame"/> objects, each of which contains
+        /// the 3D position of single photodiode.
         /// </summary>
         /// <returns>A sequence of <see cref="TS4231V1PositionDataFrame"/> objects.</returns>
         public unsafe override IObservable<TS4231V1PositionDataFrame> Generate()

--- a/OpenEphys.Onix1/TS4231V1PositionData.cs
+++ b/OpenEphys.Onix1/TS4231V1PositionData.cs
@@ -9,30 +9,33 @@ using OpenCV.Net;
 namespace OpenEphys.Onix1
 {
     /// <summary>
-    /// Produces a sequence of 3D positions from an array of Triad Semiconductor TS4231 receivers beneath
-    /// a pair of SteamVR V1 base stations.
+    /// Produces a sequence of 3D positions from an array of Triad Semiconductor TS4231 receivers beneath a
+    /// pair of SteamVR V1 base stations.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This data stream class must be linked to an appropriate configuration, such as a <see cref="ConfigureTS4231V1"/>,
-    /// in order to stream data.
+    /// This data IO operator must be linked to an appropriate configuration, such as a <see
+    /// cref="ConfigureTS4231V1"/>, using a shared <see cref="DeviceName"/>.
     /// </para>
     /// <para>
-    /// The data produced by this class contains naïve geometric estimates of positions of photodiodes attached to each TS4231 chip.
-    /// This operator makes the following assumptions about the setup:
+    /// The data produced by this class contains naïve geometric estimates of positions of photodiodes
+    /// attached to each TS4231 chip. This operator makes the following assumptions about the setup:
     /// <list type="bullet">
     /// <item><description>Two SteamVR V1 base stations are used.</description></item>
-    /// <item><description>The base stations have been synchronized with a patch cable and their modes set to ‘A’ and ‘b’, respectively.</description></item>
+    /// <item><description>The base stations have been synchronized with a patch cable and their modes set to
+    /// ‘A’ and ‘b’, respectively.</description></item>
     /// <item><description>The base stations are pointed in the same direction.</description></item>
-    /// <item><description>The Z-axis extends away the emitting face of lighthouses, X along the direction of the text on the back label,
-    /// and Y from bottom to top text on the back label.</description></item>
+    /// <item><description>The Z-axis extends away the emitting face of lighthouses, X along the direction of
+    /// the text on the back label, and Y from bottom to top text on the back label.</description></item>
     /// </list>
-    /// This operator collects a sequence of <see cref="oni.Frame"/> objects from each TS3231 receiver that are used to determine the ray from each
-    /// base station to the TS3231's photodiode. A simple geometric inversion is performed to determine the photodiodes 3D position from the values
-    /// <see cref="P"/> and <see cref="Q"/>. It does not use a predictive model or integrate data from an IMU and is therefore quite sensitive to
-    /// obstructions in and will require post-hoc processing to correct systematic errors due to optical aberrations and nonlinearities. The the
-    /// <see cref="TS4231V1Data"/> operator provides access to individual lighthouse signals that is useful for a creating more robust position
-    /// estimates using downstream processing.
+    /// This operator collects a sequence of <see cref="oni.Frame"/> objects from each TS3231 receiver that
+    /// are used to determine the ray from each base station to the TS3231's photodiode. A simple geometric
+    /// inversion is performed to determine the photodiodes 3D position from the values <see cref="P"/> and
+    /// <see cref="Q"/>. It does not use a predictive model or integrate data from an IMU and is therefore
+    /// quite sensitive to obstructions in and will require post-hoc processing to correct systematic errors
+    /// due to optical aberrations and nonlinearities. The the <see cref="TS4231V1Data"/> operator provides
+    /// access to individual lighthouse signals that is useful for a creating more robust position estimates
+    /// using downstream processing.
     /// </para>
     /// </remarks>
     [Description("Produces a sequence of 3D positions from an array of Triad Semiconductor TS4231 receivers beneath a pair of SteamVR V1 base stations.")]


### PR DESCRIPTION
- Added remarks to all device configuraiton and data IO operators indicating that they can be linked through the use of a shared DeviceName
- Fixes #207 