### PR TITLE
Add validation of Neuropixels calibration files

### DIFF
--- a/OpenEphys.Onix1.Design/GenericDeviceDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/GenericDeviceDialog.Designer.cs
@@ -43,9 +43,9 @@
             // 
             this.propertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;
             this.propertyGrid.Location = new System.Drawing.Point(0, 0);
-            this.propertyGrid.Margin = new System.Windows.Forms.Padding(2);
+            this.propertyGrid.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.propertyGrid.Name = "propertyGrid";
-            this.propertyGrid.Size = new System.Drawing.Size(252, 349);
+            this.propertyGrid.Size = new System.Drawing.Size(336, 438);
             this.propertyGrid.TabIndex = 0;
             // 
             // splitContainer1
@@ -54,7 +54,7 @@
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
             this.splitContainer1.IsSplitterFixed = true;
             this.splitContainer1.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(2);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.splitContainer1.Name = "splitContainer1";
             this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -66,19 +66,18 @@
             // 
             this.splitContainer1.Panel2.Controls.Add(this.buttonCancel);
             this.splitContainer1.Panel2.Controls.Add(this.buttonOK);
-            this.splitContainer1.Size = new System.Drawing.Size(252, 386);
-            this.splitContainer1.SplitterDistance = 349;
-            this.splitContainer1.SplitterWidth = 3;
+            this.splitContainer1.Size = new System.Drawing.Size(336, 475);
+            this.splitContainer1.SplitterDistance = 438;
             this.splitContainer1.TabIndex = 1;
             // 
             // buttonCancel
             // 
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(135, 5);
-            this.buttonCancel.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonCancel.Location = new System.Drawing.Point(180, -2);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(108, 25);
+            this.buttonCancel.Size = new System.Drawing.Size(144, 31);
             this.buttonCancel.TabIndex = 6;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
@@ -86,23 +85,23 @@
             // buttonOK
             // 
             this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOK.Location = new System.Drawing.Point(13, 5);
-            this.buttonOK.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.buttonOK.Location = new System.Drawing.Point(17, -2);
+            this.buttonOK.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOK.Name = "buttonOK";
-            this.buttonOK.Size = new System.Drawing.Size(108, 25);
+            this.buttonOK.Size = new System.Drawing.Size(144, 31);
             this.buttonOK.TabIndex = 5;
             this.buttonOK.Text = "OK";
             this.buttonOK.UseVisualStyleBackColor = true;
-            this.buttonOK.Click += new System.EventHandler(this.ButtonClick);
             // 
             // GenericDeviceDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(252, 386);
+            this.ClientSize = new System.Drawing.Size(336, 475);
             this.Controls.Add(this.splitContainer1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "GenericDeviceDialog";

--- a/OpenEphys.Onix1.Design/GenericDeviceDialog.cs
+++ b/OpenEphys.Onix1.Design/GenericDeviceDialog.cs
@@ -15,20 +15,5 @@ namespace OpenEphys.Onix1.Design
         {
             InitializeComponent();
         }
-
-        private void ButtonClick(object sender, System.EventArgs e)
-        {
-            if (sender is Button button)
-            {
-                if (button.Name == nameof(buttonOK))
-                {
-                    DialogResult = DialogResult.OK;
-                }
-                else if (button.Name == nameof(buttonCancel))
-                {
-                    DialogResult = DialogResult.Cancel;
-                }
-            }
-        }
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eDialog.Designer.cs
@@ -38,6 +38,10 @@
             System.Windows.Forms.Label apGain;
             System.Windows.Forms.Label label3;
             System.Windows.Forms.Label label1;
+            System.Windows.Forms.Label label2;
+            System.Windows.Forms.Label label4;
+            System.Windows.Forms.ToolStripStatusLabel toolStripLabelAdcCalibrationSN;
+            System.Windows.Forms.ToolStripStatusLabel toolStripLabelGainCalibrationSn;
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NeuropixelsV1eDialog));
             this.menuStrip = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -45,6 +49,9 @@
             this.panelTrackBar = new System.Windows.Forms.Panel();
             this.trackBarProbePosition = new System.Windows.Forms.TrackBar();
             this.panelOptions = new System.Windows.Forms.Panel();
+            this.textBoxLfpCorrection = new System.Windows.Forms.TextBox();
+            this.textBoxApCorrection = new System.Windows.Forms.TextBox();
+            this.buttonViewAdcs = new System.Windows.Forms.Button();
             this.buttonChooseAdcCalibrationFile = new System.Windows.Forms.Button();
             this.buttonChooseGainCalibrationFile = new System.Windows.Forms.Button();
             this.buttonEnableContacts = new System.Windows.Forms.Button();
@@ -62,6 +69,10 @@
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.toolStripAdcCalSN = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripGainCalSN = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatus = new System.Windows.Forms.ToolStripStatusLabel();
             labelPresets = new System.Windows.Forms.Label();
             adcCalibrationFile = new System.Windows.Forms.Label();
             gainCalibrationFile = new System.Windows.Forms.Label();
@@ -71,6 +82,10 @@
             apGain = new System.Windows.Forms.Label();
             label3 = new System.Windows.Forms.Label();
             label1 = new System.Windows.Forms.Label();
+            label2 = new System.Windows.Forms.Label();
+            label4 = new System.Windows.Forms.Label();
+            toolStripLabelAdcCalibrationSN = new System.Windows.Forms.ToolStripStatusLabel();
+            toolStripLabelGainCalibrationSn = new System.Windows.Forms.ToolStripStatusLabel();
             this.menuStrip.SuspendLayout();
             this.panelProbe.SuspendLayout();
             this.panelTrackBar.SuspendLayout();
@@ -78,77 +93,71 @@
             this.panelOptions.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
+            this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
             // labelPresets
             // 
             labelPresets.AutoSize = true;
-            labelPresets.Location = new System.Drawing.Point(10, 217);
-            labelPresets.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            labelPresets.Location = new System.Drawing.Point(13, 370);
             labelPresets.Name = "labelPresets";
-            labelPresets.Size = new System.Drawing.Size(46, 26);
+            labelPresets.Size = new System.Drawing.Size(56, 32);
             labelPresets.TabIndex = 25;
             labelPresets.Text = "Channel\r\nPresets:";
             // 
             // adcCalibrationFile
             // 
             adcCalibrationFile.AutoSize = true;
-            adcCalibrationFile.Location = new System.Drawing.Point(10, 9);
-            adcCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            adcCalibrationFile.MaximumSize = new System.Drawing.Size(133, 29);
+            adcCalibrationFile.Location = new System.Drawing.Point(13, 11);
+            adcCalibrationFile.MaximumSize = new System.Drawing.Size(177, 36);
             adcCalibrationFile.Name = "adcCalibrationFile";
-            adcCalibrationFile.Size = new System.Drawing.Size(103, 13);
+            adcCalibrationFile.Size = new System.Drawing.Size(130, 16);
             adcCalibrationFile.TabIndex = 11;
             adcCalibrationFile.Text = "ADC Calibration File:";
             // 
             // gainCalibrationFile
             // 
             gainCalibrationFile.AutoSize = true;
-            gainCalibrationFile.Location = new System.Drawing.Point(10, 57);
-            gainCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            gainCalibrationFile.MaximumSize = new System.Drawing.Size(133, 29);
+            gainCalibrationFile.Location = new System.Drawing.Point(13, 114);
+            gainCalibrationFile.MaximumSize = new System.Drawing.Size(177, 36);
             gainCalibrationFile.Name = "gainCalibrationFile";
-            gainCalibrationFile.Size = new System.Drawing.Size(103, 13);
+            gainCalibrationFile.Size = new System.Drawing.Size(130, 16);
             gainCalibrationFile.TabIndex = 8;
             gainCalibrationFile.Text = "Gain Calibration File:";
             // 
             // spikeFilter
             // 
             spikeFilter.AutoSize = true;
-            spikeFilter.Location = new System.Drawing.Point(10, 168);
-            spikeFilter.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            spikeFilter.Location = new System.Drawing.Point(13, 310);
             spikeFilter.Name = "spikeFilter";
-            spikeFilter.Size = new System.Drawing.Size(62, 13);
+            spikeFilter.Size = new System.Drawing.Size(77, 16);
             spikeFilter.TabIndex = 6;
             spikeFilter.Text = "Spike Filter:";
             // 
             // Reference
             // 
             Reference.AutoSize = true;
-            Reference.Location = new System.Drawing.Point(10, 195);
-            Reference.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            Reference.Location = new System.Drawing.Point(13, 343);
             Reference.Name = "Reference";
-            Reference.Size = new System.Drawing.Size(60, 13);
+            Reference.Size = new System.Drawing.Size(73, 16);
             Reference.TabIndex = 4;
             Reference.Text = "Reference:";
             // 
             // lfpGain
             // 
             lfpGain.AutoSize = true;
-            lfpGain.Location = new System.Drawing.Point(10, 139);
-            lfpGain.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            lfpGain.Location = new System.Drawing.Point(13, 244);
             lfpGain.Name = "lfpGain";
-            lfpGain.Size = new System.Drawing.Size(54, 13);
+            lfpGain.Size = new System.Drawing.Size(65, 16);
             lfpGain.TabIndex = 2;
             lfpGain.Text = "LFP Gain:";
             // 
             // apGain
             // 
             apGain.AutoSize = true;
-            apGain.Location = new System.Drawing.Point(10, 110);
-            apGain.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            apGain.Location = new System.Drawing.Point(13, 179);
             apGain.Name = "apGain";
-            apGain.Size = new System.Drawing.Size(49, 13);
+            apGain.Size = new System.Drawing.Size(59, 16);
             apGain.TabIndex = 0;
             apGain.Text = "AP Gain:";
             // 
@@ -156,9 +165,10 @@
             // 
             label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             label3.AutoSize = true;
-            label3.Location = new System.Drawing.Point(4, 0);
+            label3.Location = new System.Drawing.Point(15, 0);
+            label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             label3.Name = "label3";
-            label3.Size = new System.Drawing.Size(38, 13);
+            label3.Size = new System.Drawing.Size(46, 16);
             label3.TabIndex = 32;
             label3.Text = "10 mm";
             // 
@@ -166,11 +176,44 @@
             // 
             label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(6, 552);
+            label1.Location = new System.Drawing.Point(18, 651);
+            label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             label1.Name = "label1";
-            label1.Size = new System.Drawing.Size(32, 13);
+            label1.Size = new System.Drawing.Size(39, 16);
             label1.TabIndex = 31;
             label1.Text = "0 mm";
+            // 
+            // label2
+            // 
+            label2.AutoSize = true;
+            label2.Location = new System.Drawing.Point(13, 210);
+            label2.Name = "label2";
+            label2.Size = new System.Drawing.Size(71, 16);
+            label2.TabIndex = 38;
+            label2.Text = "Correction:";
+            // 
+            // label4
+            // 
+            label4.AutoSize = true;
+            label4.Location = new System.Drawing.Point(13, 277);
+            label4.Name = "label4";
+            label4.Size = new System.Drawing.Size(71, 16);
+            label4.TabIndex = 40;
+            label4.Text = "Correction:";
+            // 
+            // toolStripLabelAdcCalibrationSN
+            // 
+            toolStripLabelAdcCalibrationSN.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            toolStripLabelAdcCalibrationSN.Name = "toolStripLabelAdcCalibrationSN";
+            toolStripLabelAdcCalibrationSN.Size = new System.Drawing.Size(152, 20);
+            toolStripLabelAdcCalibrationSN.Text = "ADC Calibration SN: ";
+            // 
+            // toolStripLabelGainCalibrationSn
+            // 
+            toolStripLabelGainCalibrationSn.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            toolStripLabelGainCalibrationSn.Name = "toolStripLabelGainCalibrationSn";
+            toolStripLabelGainCalibrationSn.Size = new System.Drawing.Size(153, 20);
+            toolStripLabelGainCalibrationSn.Text = "Gain Calibration SN: ";
             // 
             // menuStrip
             // 
@@ -179,15 +222,15 @@
             this.fileToolStripMenuItem});
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(984, 24);
+            this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
+            this.menuStrip.Size = new System.Drawing.Size(1312, 26);
             this.menuStrip.TabIndex = 0;
             this.menuStrip.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // panelProbe
@@ -195,9 +238,10 @@
             this.panelProbe.BackColor = System.Drawing.SystemColors.Control;
             this.panelProbe.Controls.Add(this.panelTrackBar);
             this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelProbe.Location = new System.Drawing.Point(3, 3);
+            this.panelProbe.Location = new System.Drawing.Point(4, 4);
+            this.panelProbe.Margin = new System.Windows.Forms.Padding(4);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(732, 566);
+            this.panelProbe.Size = new System.Drawing.Size(976, 681);
             this.panelProbe.TabIndex = 0;
             // 
             // panelTrackBar
@@ -206,9 +250,10 @@
             this.panelTrackBar.Controls.Add(label1);
             this.panelTrackBar.Controls.Add(label3);
             this.panelTrackBar.Controls.Add(this.trackBarProbePosition);
-            this.panelTrackBar.Location = new System.Drawing.Point(691, 1);
+            this.panelTrackBar.Location = new System.Drawing.Point(915, 7);
+            this.panelTrackBar.Margin = new System.Windows.Forms.Padding(4);
             this.panelTrackBar.Name = "panelTrackBar";
-            this.panelTrackBar.Size = new System.Drawing.Size(38, 564);
+            this.panelTrackBar.Size = new System.Drawing.Size(61, 666);
             this.panelTrackBar.TabIndex = 33;
             // 
             // trackBarProbePosition
@@ -217,12 +262,12 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.trackBarProbePosition.BackColor = System.Drawing.SystemColors.Control;
-            this.trackBarProbePosition.Location = new System.Drawing.Point(3, 7);
-            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(2);
+            this.trackBarProbePosition.Location = new System.Drawing.Point(4, 9);
+            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.trackBarProbePosition.Maximum = 100;
             this.trackBarProbePosition.Name = "trackBarProbePosition";
             this.trackBarProbePosition.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBarProbePosition.Size = new System.Drawing.Size(45, 550);
+            this.trackBarProbePosition.Size = new System.Drawing.Size(56, 649);
             this.trackBarProbePosition.TabIndex = 30;
             this.trackBarProbePosition.TickFrequency = 2;
             this.trackBarProbePosition.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
@@ -232,6 +277,11 @@
             // panelOptions
             // 
             this.panelOptions.BackColor = System.Drawing.SystemColors.ControlLightLight;
+            this.panelOptions.Controls.Add(this.textBoxLfpCorrection);
+            this.panelOptions.Controls.Add(label4);
+            this.panelOptions.Controls.Add(this.textBoxApCorrection);
+            this.panelOptions.Controls.Add(label2);
+            this.panelOptions.Controls.Add(this.buttonViewAdcs);
             this.panelOptions.Controls.Add(this.buttonChooseAdcCalibrationFile);
             this.panelOptions.Controls.Add(this.buttonChooseGainCalibrationFile);
             this.panelOptions.Controls.Add(this.buttonEnableContacts);
@@ -252,67 +302,103 @@
             this.panelOptions.Controls.Add(this.comboBoxApGain);
             this.panelOptions.Controls.Add(apGain);
             this.panelOptions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelOptions.Location = new System.Drawing.Point(740, 2);
-            this.panelOptions.Margin = new System.Windows.Forms.Padding(2);
+            this.panelOptions.Location = new System.Drawing.Point(987, 2);
+            this.panelOptions.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelOptions.Name = "panelOptions";
-            this.panelOptions.Size = new System.Drawing.Size(242, 568);
+            this.panelOptions.Size = new System.Drawing.Size(322, 685);
             this.panelOptions.TabIndex = 2;
+            // 
+            // textBoxLfpCorrection
+            // 
+            this.textBoxLfpCorrection.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBoxLfpCorrection.Location = new System.Drawing.Point(101, 274);
+            this.textBoxLfpCorrection.Name = "textBoxLfpCorrection";
+            this.textBoxLfpCorrection.ReadOnly = true;
+            this.textBoxLfpCorrection.Size = new System.Drawing.Size(207, 22);
+            this.textBoxLfpCorrection.TabIndex = 41;
+            // 
+            // textBoxApCorrection
+            // 
+            this.textBoxApCorrection.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBoxApCorrection.Location = new System.Drawing.Point(101, 207);
+            this.textBoxApCorrection.Name = "textBoxApCorrection";
+            this.textBoxApCorrection.ReadOnly = true;
+            this.textBoxApCorrection.Size = new System.Drawing.Size(207, 22);
+            this.textBoxApCorrection.TabIndex = 39;
+            // 
+            // buttonViewAdcs
+            // 
+            this.buttonViewAdcs.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonViewAdcs.Enabled = false;
+            this.buttonViewAdcs.Location = new System.Drawing.Point(13, 66);
+            this.buttonViewAdcs.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.buttonViewAdcs.Name = "buttonViewAdcs";
+            this.buttonViewAdcs.Size = new System.Drawing.Size(296, 38);
+            this.buttonViewAdcs.TabIndex = 37;
+            this.buttonViewAdcs.Text = "View ADC Correction Values";
+            this.toolTip.SetToolTip(this.buttonViewAdcs, "Once an ADC calibration file is selected, this button will open a new window show" +
+        "ing the parsed ADC correction values.");
+            this.buttonViewAdcs.UseVisualStyleBackColor = true;
+            this.buttonViewAdcs.Click += new System.EventHandler(this.ViewAdcs_Click);
             // 
             // buttonChooseAdcCalibrationFile
             // 
             this.buttonChooseAdcCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseAdcCalibrationFile.Location = new System.Drawing.Point(205, 24);
-            this.buttonChooseAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonChooseAdcCalibrationFile.Location = new System.Drawing.Point(272, 30);
+            this.buttonChooseAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseAdcCalibrationFile.Name = "buttonChooseAdcCalibrationFile";
-            this.buttonChooseAdcCalibrationFile.Size = new System.Drawing.Size(28, 20);
+            this.buttonChooseAdcCalibrationFile.Size = new System.Drawing.Size(37, 25);
             this.buttonChooseAdcCalibrationFile.TabIndex = 36;
             this.buttonChooseAdcCalibrationFile.Text = "...";
             this.toolTip.SetToolTip(this.buttonChooseAdcCalibrationFile, "Browse for an ADC calibration file.");
             this.buttonChooseAdcCalibrationFile.UseVisualStyleBackColor = true;
-            this.buttonChooseAdcCalibrationFile.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonChooseAdcCalibrationFile.Click += new System.EventHandler(this.ChooseAdcCalibrationFile_Click);
             // 
             // buttonChooseGainCalibrationFile
             // 
             this.buttonChooseGainCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseGainCalibrationFile.Location = new System.Drawing.Point(205, 72);
-            this.buttonChooseGainCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonChooseGainCalibrationFile.Location = new System.Drawing.Point(272, 133);
+            this.buttonChooseGainCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseGainCalibrationFile.Name = "buttonChooseGainCalibrationFile";
-            this.buttonChooseGainCalibrationFile.Size = new System.Drawing.Size(28, 20);
+            this.buttonChooseGainCalibrationFile.Size = new System.Drawing.Size(37, 25);
             this.buttonChooseGainCalibrationFile.TabIndex = 35;
             this.buttonChooseGainCalibrationFile.Text = "...";
             this.toolTip.SetToolTip(this.buttonChooseGainCalibrationFile, "Browse for a gain calibration file.");
             this.buttonChooseGainCalibrationFile.UseVisualStyleBackColor = true;
-            this.buttonChooseGainCalibrationFile.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonChooseGainCalibrationFile.Click += new System.EventHandler(this.ChooseGainCalibrationFile_Click);
             // 
             // buttonEnableContacts
             // 
             this.buttonEnableContacts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonEnableContacts.Location = new System.Drawing.Point(10, 265);
-            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonEnableContacts.Location = new System.Drawing.Point(13, 429);
+            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonEnableContacts.Name = "buttonEnableContacts";
-            this.buttonEnableContacts.Size = new System.Drawing.Size(223, 36);
+            this.buttonEnableContacts.Size = new System.Drawing.Size(296, 44);
             this.buttonEnableContacts.TabIndex = 28;
             this.buttonEnableContacts.Text = "Enable Selected Electrodes";
             this.toolTip.SetToolTip(this.buttonEnableContacts, "Click and drag to select electrodes in the probe view. \r\nPress this button to ena" +
         "ble the selected electrodes. \r\nNot all electrode combinations are possible.");
             this.buttonEnableContacts.UseVisualStyleBackColor = true;
-            this.buttonEnableContacts.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonEnableContacts.Click += new System.EventHandler(this.EnableContacts_Click);
             // 
             // buttonClearSelections
             // 
             this.buttonClearSelections.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClearSelections.Location = new System.Drawing.Point(10, 305);
-            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonClearSelections.Location = new System.Drawing.Point(13, 478);
+            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonClearSelections.Name = "buttonClearSelections";
-            this.buttonClearSelections.Size = new System.Drawing.Size(223, 36);
+            this.buttonClearSelections.Size = new System.Drawing.Size(296, 44);
             this.buttonClearSelections.TabIndex = 27;
             this.buttonClearSelections.Text = "Clear Electrode Selection";
             this.toolTip.SetToolTip(this.buttonClearSelections, "Deselect all electrodes in the probe view. \r\nNote that this does not disable elec" +
         "trodes, but simply deselects them.");
             this.buttonClearSelections.UseVisualStyleBackColor = true;
-            this.buttonClearSelections.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonClearSelections.Click += new System.EventHandler(this.ClearSelection_Click);
             // 
             // comboBoxChannelPresets
             // 
@@ -320,33 +406,33 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxChannelPresets.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxChannelPresets.FormattingEnabled = true;
-            this.comboBoxChannelPresets.Location = new System.Drawing.Point(76, 222);
-            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBoxChannelPresets.Location = new System.Drawing.Point(101, 376);
+            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxChannelPresets.Name = "comboBoxChannelPresets";
-            this.comboBoxChannelPresets.Size = new System.Drawing.Size(157, 21);
+            this.comboBoxChannelPresets.Size = new System.Drawing.Size(207, 24);
             this.comboBoxChannelPresets.TabIndex = 26;
             // 
             // buttonResetZoom
             // 
             this.buttonResetZoom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonResetZoom.Location = new System.Drawing.Point(10, 345);
-            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonResetZoom.Location = new System.Drawing.Point(13, 528);
+            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonResetZoom.Name = "buttonResetZoom";
-            this.buttonResetZoom.Size = new System.Drawing.Size(223, 36);
+            this.buttonResetZoom.Size = new System.Drawing.Size(296, 44);
             this.buttonResetZoom.TabIndex = 22;
             this.buttonResetZoom.Text = "Reset Zoom";
             this.toolTip.SetToolTip(this.buttonResetZoom, "Reset the zoom in the probe view so that the probe is zoomed out and centered.");
             this.buttonResetZoom.UseVisualStyleBackColor = true;
-            this.buttonResetZoom.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonResetZoom.Click += new System.EventHandler(this.ResetZoom_Click);
             // 
             // checkBoxSpikeFilter
             // 
             this.checkBoxSpikeFilter.AutoSize = true;
-            this.checkBoxSpikeFilter.Location = new System.Drawing.Point(76, 167);
-            this.checkBoxSpikeFilter.Margin = new System.Windows.Forms.Padding(2);
+            this.checkBoxSpikeFilter.Location = new System.Drawing.Point(101, 309);
+            this.checkBoxSpikeFilter.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxSpikeFilter.Name = "checkBoxSpikeFilter";
-            this.checkBoxSpikeFilter.Size = new System.Drawing.Size(65, 17);
+            this.checkBoxSpikeFilter.Size = new System.Drawing.Size(80, 20);
             this.checkBoxSpikeFilter.TabIndex = 14;
             this.checkBoxSpikeFilter.Text = "Enabled";
             this.checkBoxSpikeFilter.UseVisualStyleBackColor = true;
@@ -355,25 +441,25 @@
             // 
             this.textBoxAdcCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxAdcCalibrationFile.Location = new System.Drawing.Point(10, 24);
-            this.textBoxAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxAdcCalibrationFile.Location = new System.Drawing.Point(13, 30);
+            this.textBoxAdcCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxAdcCalibrationFile.Name = "textBoxAdcCalibrationFile";
-            this.textBoxAdcCalibrationFile.Size = new System.Drawing.Size(191, 20);
+            this.textBoxAdcCalibrationFile.Size = new System.Drawing.Size(252, 22);
             this.textBoxAdcCalibrationFile.TabIndex = 12;
             this.textBoxAdcCalibrationFile.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.textBoxAdcCalibrationFile.TextChanged += new System.EventHandler(this.FileTextChanged);
+            this.textBoxAdcCalibrationFile.TextChanged += new System.EventHandler(this.AdcCalibrationFileTextChanged);
             // 
             // textBoxGainCalibrationFile
             // 
             this.textBoxGainCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxGainCalibrationFile.Location = new System.Drawing.Point(10, 72);
-            this.textBoxGainCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxGainCalibrationFile.Location = new System.Drawing.Point(13, 133);
+            this.textBoxGainCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxGainCalibrationFile.Name = "textBoxGainCalibrationFile";
-            this.textBoxGainCalibrationFile.Size = new System.Drawing.Size(191, 20);
+            this.textBoxGainCalibrationFile.Size = new System.Drawing.Size(252, 22);
             this.textBoxGainCalibrationFile.TabIndex = 9;
             this.textBoxGainCalibrationFile.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.textBoxGainCalibrationFile.TextChanged += new System.EventHandler(this.FileTextChanged);
+            this.textBoxGainCalibrationFile.TextChanged += new System.EventHandler(this.GainCalibrationFileTextChanged);
             // 
             // comboBoxReference
             // 
@@ -381,10 +467,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxReference.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxReference.FormattingEnabled = true;
-            this.comboBoxReference.Location = new System.Drawing.Point(76, 192);
-            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBoxReference.Location = new System.Drawing.Point(101, 339);
+            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxReference.Name = "comboBoxReference";
-            this.comboBoxReference.Size = new System.Drawing.Size(157, 21);
+            this.comboBoxReference.Size = new System.Drawing.Size(207, 24);
             this.comboBoxReference.TabIndex = 5;
             // 
             // comboBoxLfpGain
@@ -393,10 +479,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxLfpGain.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxLfpGain.FormattingEnabled = true;
-            this.comboBoxLfpGain.Location = new System.Drawing.Point(76, 136);
-            this.comboBoxLfpGain.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBoxLfpGain.Location = new System.Drawing.Point(101, 240);
+            this.comboBoxLfpGain.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxLfpGain.Name = "comboBoxLfpGain";
-            this.comboBoxLfpGain.Size = new System.Drawing.Size(157, 21);
+            this.comboBoxLfpGain.Size = new System.Drawing.Size(207, 24);
             this.comboBoxLfpGain.TabIndex = 3;
             // 
             // comboBoxApGain
@@ -405,33 +491,33 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxApGain.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxApGain.FormattingEnabled = true;
-            this.comboBoxApGain.Location = new System.Drawing.Point(76, 106);
-            this.comboBoxApGain.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBoxApGain.Location = new System.Drawing.Point(101, 174);
+            this.comboBoxApGain.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxApGain.Name = "comboBoxApGain";
-            this.comboBoxApGain.Size = new System.Drawing.Size(157, 21);
+            this.comboBoxApGain.Size = new System.Drawing.Size(207, 24);
             this.comboBoxApGain.TabIndex = 1;
             // 
             // buttonCancel
             // 
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(893, 2);
-            this.buttonCancel.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonCancel.Location = new System.Drawing.Point(1194, 2);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(83, 28);
+            this.buttonCancel.Size = new System.Drawing.Size(111, 34);
             this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
             // 
             // buttonOkay
             // 
-            this.buttonOkay.Location = new System.Drawing.Point(806, 2);
-            this.buttonOkay.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonOkay.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.buttonOkay.Location = new System.Drawing.Point(1077, 2);
+            this.buttonOkay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOkay.Name = "buttonOkay";
-            this.buttonOkay.Size = new System.Drawing.Size(83, 28);
+            this.buttonOkay.Size = new System.Drawing.Size(111, 34);
             this.buttonOkay.TabIndex = 0;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
-            this.buttonOkay.Click += new System.EventHandler(this.ButtonClick);
             // 
             // tableLayoutPanel1
             // 
@@ -442,12 +528,13 @@
             this.tableLayoutPanel1.Controls.Add(this.panelOptions, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(984, 612);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1312, 731);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -457,22 +544,62 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 575);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 691);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(978, 34);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1308, 38);
             this.flowLayoutPanel1.TabIndex = 0;
+            // 
+            // statusStrip1
+            // 
+            this.statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            toolStripLabelAdcCalibrationSN,
+            this.toolStripAdcCalSN,
+            toolStripLabelGainCalibrationSn,
+            this.toolStripGainCalSN,
+            this.toolStripStatus});
+            this.statusStrip1.Location = new System.Drawing.Point(0, 757);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(1312, 26);
+            this.statusStrip1.TabIndex = 34;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
+            // toolStripAdcCalSN
+            // 
+            this.toolStripAdcCalSN.AutoSize = false;
+            this.toolStripAdcCalSN.Name = "toolStripAdcCalSN";
+            this.toolStripAdcCalSN.Size = new System.Drawing.Size(120, 20);
+            this.toolStripAdcCalSN.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // toolStripGainCalSN
+            // 
+            this.toolStripGainCalSN.AutoSize = false;
+            this.toolStripGainCalSN.Name = "toolStripGainCalSN";
+            this.toolStripGainCalSN.Size = new System.Drawing.Size(120, 20);
+            this.toolStripGainCalSN.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // toolStripStatus
+            // 
+            this.toolStripStatus.Image = global::OpenEphys.Onix1.Design.Properties.Resources.StatusWarningImage;
+            this.toolStripStatus.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.toolStripStatus.Name = "toolStripStatus";
+            this.toolStripStatus.Size = new System.Drawing.Size(69, 20);
+            this.toolStripStatus.Text = "Status";
+            this.toolStripStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // NeuropixelsV1eDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(984, 636);
+            this.ClientSize = new System.Drawing.Size(1312, 783);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip);
+            this.Controls.Add(this.statusStrip1);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip;
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "NeuropixelsV1eDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV1e Configuration";
@@ -486,6 +613,8 @@
             this.panelOptions.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.flowLayoutPanel1.ResumeLayout(false);
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -516,5 +645,12 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private System.Windows.Forms.ToolTip toolTip;
+        private System.Windows.Forms.Button buttonViewAdcs;
+        private System.Windows.Forms.TextBox textBoxApCorrection;
+        private System.Windows.Forms.TextBox textBoxLfpCorrection;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripAdcCalSN;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripGainCalSN;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatus;
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eDialog.cs
@@ -13,6 +13,8 @@ namespace OpenEphys.Onix1.Design
     {
         readonly NeuropixelsV1eChannelConfigurationDialog ChannelConfiguration;
 
+        private NeuropixelsV1eAdc[] Adcs = null;
+
         private enum ChannelPreset
         {
             BankA,
@@ -62,18 +64,18 @@ namespace OpenEphys.Onix1.Design
 
             comboBoxApGain.DataSource = Enum.GetValues(typeof(NeuropixelsV1Gain));
             comboBoxApGain.SelectedItem = ConfigureNode.ProbeConfiguration.SpikeAmplifierGain;
-            comboBoxApGain.SelectedIndexChanged += SelectedIndexChanged;
+            comboBoxApGain.SelectedIndexChanged += SpikeAmplifierGainIndexChanged;
 
             comboBoxLfpGain.DataSource = Enum.GetValues(typeof(NeuropixelsV1Gain));
             comboBoxLfpGain.SelectedItem = ConfigureNode.ProbeConfiguration.LfpAmplifierGain;
-            comboBoxLfpGain.SelectedIndexChanged += SelectedIndexChanged;
+            comboBoxLfpGain.SelectedIndexChanged += LfpAmplifierGainIndexChanged;
 
             comboBoxReference.DataSource = Enum.GetValues(typeof(NeuropixelsV1ReferenceSource));
             comboBoxReference.SelectedItem = ConfigureNode.ProbeConfiguration.Reference;
-            comboBoxReference.SelectedIndexChanged += SelectedIndexChanged;
+            comboBoxReference.SelectedIndexChanged += ReferenceIndexChanged;
 
             checkBoxSpikeFilter.Checked = ConfigureNode.ProbeConfiguration.SpikeFilter;
-            checkBoxSpikeFilter.CheckedChanged += SelectedIndexChanged;
+            checkBoxSpikeFilter.CheckedChanged += SpikeFilterIndexChanged;
 
             textBoxAdcCalibrationFile.Text = ConfigureNode.AdcCalibrationFile;
 
@@ -81,7 +83,7 @@ namespace OpenEphys.Onix1.Design
 
             comboBoxChannelPresets.DataSource = Enum.GetValues(typeof(ChannelPreset));
             CheckForExistingChannelPreset();
-            comboBoxChannelPresets.SelectedIndexChanged += SelectedIndexChanged;
+            comboBoxChannelPresets.SelectedIndexChanged += ChannelPresetIndexChanged;
 
             CheckStatus();
         }
@@ -103,61 +105,52 @@ namespace OpenEphys.Onix1.Design
 
         private void ResizeTrackBar(object sender, EventArgs e)
         {
-            if (sender is ChannelConfigurationDialog dialog)
-            {
-                panelTrackBar.Height = dialog.zedGraphChannels.Size.Height;
-                panelTrackBar.Location = new Point(panelProbe.Size.Width - panelTrackBar.Width, ChannelConfiguration.zedGraphChannels.Location.Y);
-            }
+            panelTrackBar.Height = ((ChannelConfigurationDialog)sender).zedGraphChannels.Size.Height;
+            panelTrackBar.Location = new Point(panelProbe.Size.Width - panelTrackBar.Width, ChannelConfiguration.zedGraphChannels.Location.Y);
         }
 
-        private void FileTextChanged(object sender, EventArgs e)
+        private void GainCalibrationFileTextChanged(object sender, EventArgs e)
         {
-            if (sender is TextBox textBox && textBox != null)
-            {
-                if (textBox.Name == nameof(textBoxGainCalibrationFile))
-                {
-                    ConfigureNode.GainCalibrationFile = textBox.Text;
-                }
-                else if (textBox.Name == nameof(textBoxAdcCalibrationFile))
-                {
-                    ConfigureNode.AdcCalibrationFile = textBox.Text;
-                }
-            }
-
+            ConfigureNode.GainCalibrationFile = ((TextBox)sender).Text;
             CheckStatus();
         }
 
-        private void SelectedIndexChanged(object sender, EventArgs e)
+        private void AdcCalibrationFileTextChanged(object sender, EventArgs e)
         {
-            if (sender is ComboBox comboBox && comboBox != null)
+            ConfigureNode.AdcCalibrationFile = ((TextBox)sender).Text;
+            CheckStatus();
+        }
+
+        private void SpikeAmplifierGainIndexChanged(object sender, EventArgs e)
+        {
+            ConfigureNode.ProbeConfiguration.SpikeAmplifierGain = (NeuropixelsV1Gain)((ComboBox)sender).SelectedItem;
+            CheckStatus();
+        }
+
+        private void LfpAmplifierGainIndexChanged(object sender, EventArgs e)
+        {
+            ConfigureNode.ProbeConfiguration.LfpAmplifierGain = (NeuropixelsV1Gain)((ComboBox)sender).SelectedItem;
+            CheckStatus();
+        }
+
+        private void ReferenceIndexChanged(object sender, EventArgs e)
+        {
+            ConfigureNode.ProbeConfiguration.Reference = (NeuropixelsV1ReferenceSource)((ComboBox)sender).SelectedItem;
+        }
+
+        private void ChannelPresetIndexChanged(object sender, EventArgs e)
+        {
+            var channelPreset = (ChannelPreset)((ComboBox)sender).SelectedItem;
+
+            if (channelPreset != ChannelPreset.None)
             {
-                if (comboBox.Name == nameof(comboBoxApGain))
-                {
-                    ConfigureNode.ProbeConfiguration.SpikeAmplifierGain = (NeuropixelsV1Gain)comboBox.SelectedItem;
-                }
-                else if (comboBox.Name == nameof(comboBoxLfpGain))
-                {
-                    ConfigureNode.ProbeConfiguration.LfpAmplifierGain = (NeuropixelsV1Gain)comboBox.SelectedItem;
-                }
-                else if (comboBox.Name == nameof(comboBoxReference))
-                {
-                    ConfigureNode.ProbeConfiguration.Reference = (NeuropixelsV1ReferenceSource)comboBox.SelectedItem;
-                }
-                else if (comboBox.Name == nameof(comboBoxChannelPresets))
-                {
-                    if ((ChannelPreset)comboBox.SelectedItem != ChannelPreset.None)
-                    {
-                        SetChannelPreset((ChannelPreset)comboBox.SelectedItem);
-                    }
-                }
+                SetChannelPreset(channelPreset);
             }
-            else if (sender is CheckBox checkBox && checkBox != null)
-            {
-                if (checkBox.Name == nameof(checkBoxSpikeFilter))
-                {
-                    ConfigureNode.ProbeConfiguration.SpikeFilter = checkBox.Checked;
-                }
-            }
+        }
+
+        private void SpikeFilterIndexChanged(object sender, EventArgs e)
+        {
+            ConfigureNode.ProbeConfiguration.SpikeFilter = ((CheckBox)sender).Checked;
         }
 
         private void SetChannelPreset(ChannelPreset preset)
@@ -239,74 +232,183 @@ namespace OpenEphys.Onix1.Design
 
         private void CheckStatus()
         {
-            if (File.Exists(ConfigureNode.AdcCalibrationFile) && File.Exists(ConfigureNode.GainCalibrationFile))
+            const string NoFileSelected = "No file selected.";
+            const string InvalidFile = "Invalid file.";
+
+            NeuropixelsV1eAdcCalibration? adcCalibration;
+
+            try
             {
-                panelProbe.Visible = true;
+                adcCalibration = NeuropixelsV1Helper.TryParseAdcCalibrationFile(ConfigureNode.AdcCalibrationFile);
+            }
+            catch (IOException ex)
+            {
+                MessageBox.Show($"An I/O error occurred while parsing {ConfigureNode.AdcCalibrationFile}. Check the error log below." +
+                    $"\n\n" + ex.Message);
+                return;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                MessageBox.Show($"An unauthorized access error occurred while parsing {ConfigureNode.AdcCalibrationFile}. Check the error log below." +
+                    $"\n\n" + ex.Message);
+                return;
+            }
+
+            Adcs = adcCalibration.HasValue
+                   ? adcCalibration.Value.Adcs
+                   : null;
+
+            buttonViewAdcs.Enabled = adcCalibration.HasValue;
+            toolStripAdcCalSN.Text = adcCalibration.HasValue
+                                     ? adcCalibration.Value.SerialNumber.ToString()
+                                     : string.IsNullOrEmpty(ConfigureNode.AdcCalibrationFile)
+                                       ? NoFileSelected
+                                       : InvalidFile;
+
+            NeuropixelsV1eGainCorrection? gainCorrection;
+
+            try
+            {
+                gainCorrection = NeuropixelsV1Helper.TryParseGainCalibrationFile(ConfigureNode.GainCalibrationFile, 
+                                                                                 ConfigureNode.ProbeConfiguration.SpikeAmplifierGain,
+                                                                                 ConfigureNode.ProbeConfiguration.LfpAmplifierGain);
+            }
+            catch (IOException ex)
+            {
+                MessageBox.Show($"An I/O error occurred while parsing {ConfigureNode.GainCalibrationFile}. Check the error log below." +
+                    $"\n\n" + ex.Message);
+                return;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                MessageBox.Show($"An unauthorized access error occurred while parsing {ConfigureNode.GainCalibrationFile}. Check the error log below." +
+                    $"\n\n" + ex.Message);
+                return;
+            }
+
+            toolStripGainCalSN.Text = gainCorrection.HasValue
+                                      ? gainCorrection.Value.SerialNumber.ToString()
+                                      : string.IsNullOrEmpty(ConfigureNode.GainCalibrationFile)
+                                        ? NoFileSelected
+                                        : InvalidFile;
+
+            textBoxApCorrection.Text = gainCorrection.HasValue
+                                       ? gainCorrection.Value.ApGainCorrectionFactor.ToString()
+                                       : "";
+
+            textBoxLfpCorrection.Text = gainCorrection.HasValue
+                                        ? gainCorrection.Value.LfpGainCorrectionFactor.ToString()
+                                        : "";
+
+            panelProbe.Visible = adcCalibration.HasValue && gainCorrection.HasValue;
+
+            if (toolStripAdcCalSN.Text == NoFileSelected || toolStripGainCalSN.Text == NoFileSelected)
+            {
+                toolStripStatus.Image = Properties.Resources.StatusRefreshImage;
+                toolStripStatus.Text = "Select files.";
+            }
+            else if (toolStripAdcCalSN.Text == InvalidFile || toolStripGainCalSN.Text == InvalidFile)
+            {
+                toolStripStatus.Image = Properties.Resources.StatusCriticalImage;
+                toolStripStatus.Text = "Invalid files.";
+            }
+            else if (toolStripAdcCalSN.Text != toolStripGainCalSN.Text)
+            {
+                toolStripStatus.Image = Properties.Resources.StatusBlockedImage;
+                toolStripStatus.Text = "Serial number mismatch.";
             }
             else
             {
-                panelProbe.Visible = false;
+                toolStripStatus.Image = Properties.Resources.StatusReadyImage;
+                toolStripStatus.Text = "Ready.";
             }
         }
 
-        private void ButtonClick(object sender, EventArgs e)
+        private void ChooseGainCalibrationFile_Click(object sender, EventArgs e)
         {
-            if (sender is Button button && button != null)
+            var ofd = new OpenFileDialog()
             {
-                if (button.Name == nameof(buttonOkay))
-                {
-                    DialogResult = DialogResult.OK;
-                }
-                else if (button.Name == nameof(buttonChooseGainCalibrationFile))
-                {
-                    var ofd = new OpenFileDialog()
-                    {
-                        CheckFileExists = true,
-                        Filter = "Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv|All Files|*.*",
-                        FilterIndex = 0
-                    };
+                CheckFileExists = true,
+                Filter = "Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv|All Files|*.*",
+                FilterIndex = 0
+            };
 
-                    if (ofd.ShowDialog() == DialogResult.OK)
-                    {
-                        textBoxGainCalibrationFile.Text = ofd.FileName;
-                    }
-                }
-                else if (button.Name == nameof(buttonChooseAdcCalibrationFile))
-                {
-                    var ofd = new OpenFileDialog()
-                    {
-                        CheckFileExists = true,
-                        Filter = "ADC calibration files (*_ADCCalibration.csv)|*_ADCCalibration.csv|All Files|*.*",
-                        FilterIndex = 0
-                    };
-
-                    if (ofd.ShowDialog() == DialogResult.OK)
-                    {
-                        textBoxAdcCalibrationFile.Text = ofd.FileName;
-                    }
-                }
-                else if (button.Name == nameof(buttonResetZoom))
-                {
-                    ResetZoom();
-                }
-                else if (button.Name == nameof(buttonClearSelections))
-                {
-                    ChannelConfiguration.SetAllSelections(false);
-                    ChannelConfiguration.HighlightEnabledContacts();
-                    ChannelConfiguration.HighlightSelectedContacts();
-                    ChannelConfiguration.UpdateContactLabels();
-                    ChannelConfiguration.RefreshZedGraph();
-                }
-                else if (button.Name == nameof(buttonEnableContacts))
-                {
-                    EnableSelectedContacts();
-                    ChannelConfiguration.SetAllSelections(false);
-                    ChannelConfiguration.HighlightEnabledContacts();
-                    ChannelConfiguration.HighlightSelectedContacts();
-                    ChannelConfiguration.UpdateContactLabels();
-                    ChannelConfiguration.RefreshZedGraph();
-                }
+            if (ofd.ShowDialog() == DialogResult.OK)
+            {
+                textBoxGainCalibrationFile.Text = ofd.FileName;
             }
+
+            CheckStatus();
+        }
+
+        private void ChooseAdcCalibrationFile_Click(object sender, EventArgs e)
+        {
+            var ofd = new OpenFileDialog()
+            {
+                CheckFileExists = true,
+                Filter = "ADC calibration files (*_ADCCalibration.csv)|*_ADCCalibration.csv|All Files|*.*",
+                FilterIndex = 0
+            };
+
+            if (ofd.ShowDialog() == DialogResult.OK)
+            {
+                textBoxAdcCalibrationFile.Text = ofd.FileName;
+            }
+
+            CheckStatus();
+        }
+
+        private void ResetZoom_Click(object sender, EventArgs e)
+        {
+            ResetZoom();
+        }
+
+        private void ClearSelection_Click(object sender, EventArgs e)
+        {
+            DeselectContacts();
+        }
+
+        private void EnableContacts_Click(object sender, EventArgs e)
+        {
+            EnableSelectedContacts();
+            DeselectContacts();
+        }
+
+        private void ViewAdcs_Click(object sender, EventArgs e)
+        {
+            if (Adcs == null)
+                return;
+
+            System.Resources.ResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NeuropixelsV1eDialog));
+
+            var adcForm = new Form()
+            {
+                Size = new Size(600, 1000),
+                Text = "View ADC Correction Values",
+                Icon = (Icon)resources.GetObject("$this.Icon"),
+                StartPosition = FormStartPosition.CenterParent,
+            };
+
+            var dataGridView = new DataGridView
+            {
+                DataSource = Adcs,
+                AllowUserToAddRows = false,
+                AllowUserToDeleteRows = false,
+                AllowUserToOrderColumns = false,
+                ReadOnly = true,
+                ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize,
+                Dock = DockStyle.Fill,
+                Location = new Point(0, 0),
+                Margin = new Padding(2),
+                Name = "dataGridViewAdcs",
+                RowHeadersWidth = 62,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill,
+            };
+            dataGridView.RowTemplate.Height = 28;
+
+            adcForm.Controls.Add(dataGridView);
+
+            adcForm.ShowDialog();
         }
 
         private void EnableSelectedContacts()
@@ -319,6 +421,15 @@ namespace OpenEphys.Onix1.Design
             ChannelConfiguration.EnableElectrodes(selectedElectrodes);
 
             CheckForExistingChannelPreset();
+        }
+
+        private void DeselectContacts()
+        {
+            ChannelConfiguration.SetAllSelections(false);
+            ChannelConfiguration.HighlightEnabledContacts();
+            ChannelConfiguration.HighlightSelectedContacts();
+            ChannelConfiguration.UpdateContactLabels();
+            ChannelConfiguration.RefreshZedGraph();
         }
 
         private void ResetZoom()
@@ -336,13 +447,7 @@ namespace OpenEphys.Onix1.Design
 
         private void TrackBarScroll(object sender, EventArgs e)
         {
-            if (sender is TrackBar trackBar && trackBar != null)
-            {
-                if (trackBar.Name == nameof(trackBarProbePosition))
-                {
-                    MoveToVerticalPosition(trackBar.Value / 100.0f);
-                }
-            }
+            MoveToVerticalPosition(((TrackBar)sender).Value / 100.0f);
         }
 
         private void UpdateTrackBarLocation(object sender, EventArgs e)

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eDialog.cs
@@ -243,14 +243,12 @@ namespace OpenEphys.Onix1.Design
             }
             catch (IOException ex)
             {
-                MessageBox.Show($"An I/O error occurred while parsing {ConfigureNode.AdcCalibrationFile}. Check the error log below." +
-                    $"\n\n" + ex.Message);
+                MessageBox.Show(ex.Message, "I/O error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
             catch (UnauthorizedAccessException ex)
             {
-                MessageBox.Show($"An unauthorized access error occurred while parsing {ConfigureNode.AdcCalibrationFile}. Check the error log below." +
-                    $"\n\n" + ex.Message);
+                MessageBox.Show(ex.Message, "Unauthorized access error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -275,14 +273,12 @@ namespace OpenEphys.Onix1.Design
             }
             catch (IOException ex)
             {
-                MessageBox.Show($"An I/O error occurred while parsing {ConfigureNode.GainCalibrationFile}. Check the error log below." +
-                    $"\n\n" + ex.Message);
+                MessageBox.Show(ex.Message, "I/O error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
             catch (UnauthorizedAccessException ex)
             {
-                MessageBox.Show($"An unauthorized access error occurred while parsing {ConfigureNode.GainCalibrationFile}. Check the error log below." +
-                    $"\n\n" + ex.Message);
+                MessageBox.Show(ex.Message, "Unauthorized access error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -330,7 +326,11 @@ namespace OpenEphys.Onix1.Design
             {
                 CheckFileExists = true,
                 Filter = "Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv|All Files|*.*",
-                FilterIndex = 0
+                FilterIndex = 0,
+                InitialDirectory = File.Exists(textBoxGainCalibrationFile.Text) ?
+                                   Path.GetDirectoryName(textBoxGainCalibrationFile.Text) :
+                                   ""
+
             };
 
             if (ofd.ShowDialog() == DialogResult.OK)
@@ -347,7 +347,10 @@ namespace OpenEphys.Onix1.Design
             {
                 CheckFileExists = true,
                 Filter = "ADC calibration files (*_ADCCalibration.csv)|*_ADCCalibration.csv|All Files|*.*",
-                FilterIndex = 0
+                FilterIndex = 0,
+                InitialDirectory = File.Exists(textBoxAdcCalibrationFile.Text) ?
+                                   Path.GetDirectoryName(textBoxAdcCalibrationFile.Text) :
+                                   ""
             };
 
             if (ofd.ShowDialog() == DialogResult.OK)

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eDialog.resx
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eDialog.resx
@@ -144,11 +144,26 @@
   <metadata name="label1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
+  <metadata name="label2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <metadata name="label4.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <metadata name="toolStripLabelAdcCalibrationSN.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <metadata name="toolStripLabelGainCalibrationSn.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
   <metadata name="menuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>365, 17</value>
+  </metadata>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>473, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>41</value>

--- a/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV1eHeadstageDialog.Designer.cs
@@ -53,21 +53,21 @@
             this.tabControl1.Controls.Add(this.tabPageNeuropixelsV1e);
             this.tabControl1.Controls.Add(this.tabPageBno055);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControl1.Location = new System.Drawing.Point(2, 2);
-            this.tabControl1.Margin = new System.Windows.Forms.Padding(2);
+            this.tabControl1.Location = new System.Drawing.Point(3, 2);
+            this.tabControl1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(1013, 585);
+            this.tabControl1.Size = new System.Drawing.Size(1350, 732);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPageNeuropixelsV1e
             // 
             this.tabPageNeuropixelsV1e.Controls.Add(this.panelNeuropixelsV1e);
-            this.tabPageNeuropixelsV1e.Location = new System.Drawing.Point(4, 22);
-            this.tabPageNeuropixelsV1e.Margin = new System.Windows.Forms.Padding(2);
+            this.tabPageNeuropixelsV1e.Location = new System.Drawing.Point(4, 25);
+            this.tabPageNeuropixelsV1e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageNeuropixelsV1e.Name = "tabPageNeuropixelsV1e";
-            this.tabPageNeuropixelsV1e.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPageNeuropixelsV1e.Size = new System.Drawing.Size(1005, 559);
+            this.tabPageNeuropixelsV1e.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tabPageNeuropixelsV1e.Size = new System.Drawing.Size(1342, 703);
             this.tabPageNeuropixelsV1e.TabIndex = 0;
             this.tabPageNeuropixelsV1e.Text = "NeuropixelsV1e";
             this.tabPageNeuropixelsV1e.UseVisualStyleBackColor = true;
@@ -75,20 +75,20 @@
             // panelNeuropixelsV1e
             // 
             this.panelNeuropixelsV1e.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelNeuropixelsV1e.Location = new System.Drawing.Point(2, 2);
-            this.panelNeuropixelsV1e.Margin = new System.Windows.Forms.Padding(2);
+            this.panelNeuropixelsV1e.Location = new System.Drawing.Point(3, 2);
+            this.panelNeuropixelsV1e.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelNeuropixelsV1e.Name = "panelNeuropixelsV1e";
-            this.panelNeuropixelsV1e.Size = new System.Drawing.Size(1001, 555);
+            this.panelNeuropixelsV1e.Size = new System.Drawing.Size(1336, 699);
             this.panelNeuropixelsV1e.TabIndex = 0;
             // 
             // tabPageBno055
             // 
             this.tabPageBno055.Controls.Add(this.panelBno055);
-            this.tabPageBno055.Location = new System.Drawing.Point(4, 22);
-            this.tabPageBno055.Margin = new System.Windows.Forms.Padding(2);
+            this.tabPageBno055.Location = new System.Drawing.Point(4, 25);
+            this.tabPageBno055.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabPageBno055.Name = "tabPageBno055";
-            this.tabPageBno055.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPageBno055.Size = new System.Drawing.Size(1005, 559);
+            this.tabPageBno055.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tabPageBno055.Size = new System.Drawing.Size(1343, 691);
             this.tabPageBno055.TabIndex = 1;
             this.tabPageBno055.Text = "Bno055";
             this.tabPageBno055.UseVisualStyleBackColor = true;
@@ -96,19 +96,19 @@
             // panelBno055
             // 
             this.panelBno055.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelBno055.Location = new System.Drawing.Point(2, 2);
-            this.panelBno055.Margin = new System.Windows.Forms.Padding(2);
+            this.panelBno055.Location = new System.Drawing.Point(3, 2);
+            this.panelBno055.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelBno055.Name = "panelBno055";
-            this.panelBno055.Size = new System.Drawing.Size(1001, 555);
+            this.panelBno055.Size = new System.Drawing.Size(1337, 687);
             this.panelBno055.TabIndex = 0;
             // 
             // buttonCancel
             // 
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(901, 2);
-            this.buttonCancel.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonCancel.Location = new System.Drawing.Point(1238, 2);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(108, 28);
+            this.buttonCancel.Size = new System.Drawing.Size(111, 34);
             this.buttonCancel.TabIndex = 6;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
@@ -117,10 +117,10 @@
             // 
             this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonOK.Location = new System.Drawing.Point(789, 2);
-            this.buttonOK.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonOK.Location = new System.Drawing.Point(1121, 2);
+            this.buttonOK.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOK.Name = "buttonOK";
-            this.buttonOK.Size = new System.Drawing.Size(108, 28);
+            this.buttonOK.Size = new System.Drawing.Size(111, 34);
             this.buttonOK.TabIndex = 5;
             this.buttonOK.Text = "OK";
             this.buttonOK.UseVisualStyleBackColor = true;
@@ -132,15 +132,15 @@
             this.fileToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip1.Size = new System.Drawing.Size(1017, 24);
+            this.menuStrip1.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
+            this.menuStrip1.Size = new System.Drawing.Size(1356, 26);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tableLayoutPanel1
@@ -150,12 +150,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1017, 629);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1356, 778);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -164,22 +165,23 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOK);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 592);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 738);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(1011, 34);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1352, 38);
             this.flowLayoutPanel1.TabIndex = 0;
             // 
             // NeuropixelsV1eHeadstageDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1017, 653);
+            this.ClientSize = new System.Drawing.Size(1356, 804);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip1);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "NeuropixelsV1eHeadstageDialog";
             this.Text = "NeuropixelsV1e Headstage Configuration";
             this.tabControl1.ResumeLayout(false);

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.Designer.cs
@@ -48,49 +48,49 @@
             this.fileToolStripMenuItem});
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(854, 24);
+            this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
+            this.menuStrip.Size = new System.Drawing.Size(1139, 26);
             this.menuStrip.TabIndex = 0;
             this.menuStrip.Text = "menuStripNeuropixelsV2e";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // tabControlProbe
             // 
             this.tabControlProbe.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControlProbe.Location = new System.Drawing.Point(2, 2);
-            this.tabControlProbe.Margin = new System.Windows.Forms.Padding(2);
+            this.tabControlProbe.Location = new System.Drawing.Point(3, 2);
+            this.tabControlProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabControlProbe.Name = "tabControlProbe";
             this.tabControlProbe.SelectedIndex = 0;
-            this.tabControlProbe.Size = new System.Drawing.Size(850, 510);
+            this.tabControlProbe.Size = new System.Drawing.Size(1133, 632);
             this.tabControlProbe.TabIndex = 1;
             // 
             // buttonCancel
             // 
-            this.buttonCancel.Location = new System.Drawing.Point(763, 2);
-            this.buttonCancel.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonCancel.Location = new System.Drawing.Point(1017, 2);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(83, 28);
+            this.buttonCancel.Size = new System.Drawing.Size(111, 34);
             this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
-            this.buttonCancel.Click += new System.EventHandler(this.ButtonClick);
             // 
             // buttonOkay
             // 
             this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOkay.Location = new System.Drawing.Point(676, 2);
-            this.buttonOkay.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonOkay.Location = new System.Drawing.Point(900, 2);
+            this.buttonOkay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOkay.Name = "buttonOkay";
-            this.buttonOkay.Size = new System.Drawing.Size(83, 28);
+            this.buttonOkay.Size = new System.Drawing.Size(111, 34);
             this.buttonOkay.TabIndex = 0;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
-            this.buttonOkay.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonOkay.Click += new System.EventHandler(this.Okay_Click);
             // 
             // tableLayoutPanel1
             // 
@@ -99,12 +99,13 @@
             this.tableLayoutPanel1.Controls.Add(this.tabControlProbe, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(854, 554);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 49F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1139, 685);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -113,22 +114,23 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 517);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 640);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(848, 34);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1131, 41);
             this.flowLayoutPanel1.TabIndex = 2;
             // 
             // NeuropixelsV2eDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(854, 578);
+            this.ClientSize = new System.Drawing.Size(1139, 711);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.menuStrip);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip;
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "NeuropixelsV2eDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV2e Configuration";

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eDialog.cs
@@ -97,21 +97,11 @@ namespace OpenEphys.Onix1.Design
             }
         }
 
-        internal void ButtonClick(object sender, EventArgs e)
+        internal void Okay_Click(object sender, EventArgs e)
         {
-            if (sender is Button button && button != null)
-            {
-                if (button.Name == nameof(buttonOkay))
-                {
-                    SaveVariables();
+            SaveVariables();
 
-                    DialogResult = DialogResult.OK;
-                }
-                else if (button.Name == nameof(buttonCancel))
-                {
-                    DialogResult = DialogResult.Cancel;
-                }
-            }
+            DialogResult = DialogResult.OK;
         }
 
         internal void SaveVariables()

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.Designer.cs
@@ -70,7 +70,7 @@
             this.buttonOkay.TabIndex = 5;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
-            this.buttonOkay.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonOkay.Click += new System.EventHandler(this.Okay_Click);
             // 
             // menuStrip1
             // 

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eHeadstageDialog.cs
@@ -62,17 +62,11 @@ namespace OpenEphys.Onix1.Design
             DialogBno055.Invalidate();
         }
 
-        private void ButtonClick(object sender, System.EventArgs e)
+        private void Okay_Click(object sender, System.EventArgs e)
         {
-            if (sender is Button button && button != null)
-            {
-                if (button.Name == nameof(buttonOkay))
-                {
-                    DialogNeuropixelsV2e.SaveVariables();
+            DialogNeuropixelsV2e.SaveVariables();
 
-                    DialogResult = DialogResult.OK;
-                }
-            }
+            DialogResult = DialogResult.OK;
         }
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.Designer.cs
@@ -34,6 +34,8 @@
             System.Windows.Forms.Label probeCalibrationFile;
             System.Windows.Forms.Label Reference;
             System.Windows.Forms.Label labelPresets;
+            System.Windows.Forms.Label label1;
+            System.Windows.Forms.ToolStripStatusLabel toolStripLabelGainCalibrationSN;
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NeuropixelsV2eProbeConfigurationDialog));
             this.menuStrip = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -46,6 +48,7 @@
             this.panelTrackBar = new System.Windows.Forms.Panel();
             this.trackBarProbePosition = new System.Windows.Forms.TrackBar();
             this.panelChannelOptions = new System.Windows.Forms.Panel();
+            this.textBoxGainCorrection = new System.Windows.Forms.TextBox();
             this.textBoxProbeCalibrationFile = new System.Windows.Forms.TextBox();
             this.comboBoxReference = new System.Windows.Forms.ComboBox();
             this.comboBoxChannelPresets = new System.Windows.Forms.ComboBox();
@@ -53,11 +56,15 @@
             this.buttonOkay = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.toolStripGainCalSN = new System.Windows.Forms.ToolStripStatusLabel();
             label6 = new System.Windows.Forms.Label();
             label7 = new System.Windows.Forms.Label();
             probeCalibrationFile = new System.Windows.Forms.Label();
             Reference = new System.Windows.Forms.Label();
             labelPresets = new System.Windows.Forms.Label();
+            label1 = new System.Windows.Forms.Label();
+            toolStripLabelGainCalibrationSN = new System.Windows.Forms.ToolStripStatusLabel();
             this.menuStrip.SuspendLayout();
             this.panelProbe.SuspendLayout();
             this.panelTrackBar.SuspendLayout();
@@ -65,16 +72,16 @@
             this.panelChannelOptions.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
+            this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
             // label6
             // 
             label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             label6.AutoSize = true;
-            label6.Location = new System.Drawing.Point(0, 440);
-            label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            label6.Location = new System.Drawing.Point(0, 542);
             label6.Name = "label6";
-            label6.Size = new System.Drawing.Size(32, 13);
+            label6.Size = new System.Drawing.Size(39, 16);
             label6.TabIndex = 28;
             label6.Text = "0 mm";
             // 
@@ -83,9 +90,8 @@
             label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             label7.AutoSize = true;
             label7.Location = new System.Drawing.Point(0, 0);
-            label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             label7.Name = "label7";
-            label7.Size = new System.Drawing.Size(38, 13);
+            label7.Size = new System.Drawing.Size(46, 16);
             label7.TabIndex = 29;
             label7.Text = "10 mm";
             label7.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -93,33 +99,46 @@
             // probeCalibrationFile
             // 
             probeCalibrationFile.AutoSize = true;
-            probeCalibrationFile.Location = new System.Drawing.Point(8, 9);
-            probeCalibrationFile.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            probeCalibrationFile.MaximumSize = new System.Drawing.Size(133, 29);
+            probeCalibrationFile.Location = new System.Drawing.Point(15, 11);
+            probeCalibrationFile.MaximumSize = new System.Drawing.Size(177, 36);
             probeCalibrationFile.Name = "probeCalibrationFile";
-            probeCalibrationFile.Size = new System.Drawing.Size(109, 13);
+            probeCalibrationFile.Size = new System.Drawing.Size(139, 16);
             probeCalibrationFile.TabIndex = 32;
             probeCalibrationFile.Text = "Probe Calibration File:";
             // 
             // Reference
             // 
             Reference.AutoSize = true;
-            Reference.Location = new System.Drawing.Point(8, 62);
-            Reference.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            Reference.Location = new System.Drawing.Point(15, 114);
             Reference.Name = "Reference";
-            Reference.Size = new System.Drawing.Size(60, 13);
+            Reference.Size = new System.Drawing.Size(73, 16);
             Reference.TabIndex = 30;
             Reference.Text = "Reference:";
             // 
             // labelPresets
             // 
             labelPresets.AutoSize = true;
-            labelPresets.Location = new System.Drawing.Point(8, 94);
-            labelPresets.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            labelPresets.Location = new System.Drawing.Point(15, 147);
             labelPresets.Name = "labelPresets";
-            labelPresets.Size = new System.Drawing.Size(49, 26);
+            labelPresets.Size = new System.Drawing.Size(59, 32);
             labelPresets.TabIndex = 23;
             labelPresets.Text = "Channel \nPresets:";
+            // 
+            // label1
+            // 
+            label1.AutoSize = true;
+            label1.Location = new System.Drawing.Point(15, 63);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(71, 32);
+            label1.TabIndex = 35;
+            label1.Text = "Gain\r\nCorrection:";
+            // 
+            // toolStripLabelGainCalibrationSN
+            // 
+            toolStripLabelGainCalibrationSN.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            toolStripLabelGainCalibrationSN.Name = "toolStripLabelGainCalibrationSN";
+            toolStripLabelGainCalibrationSN.Size = new System.Drawing.Size(153, 20);
+            toolStripLabelGainCalibrationSN.Text = "Gain Calibration SN: ";
             // 
             // menuStrip
             // 
@@ -128,83 +147,83 @@
             this.fileToolStripMenuItem});
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
-            this.menuStrip.Size = new System.Drawing.Size(834, 24);
+            this.menuStrip.Padding = new System.Windows.Forms.Padding(5, 1, 0, 1);
+            this.menuStrip.Size = new System.Drawing.Size(1112, 26);
             this.menuStrip.TabIndex = 0;
             this.menuStrip.Text = "menuStripNeuropixelsV2e";
             // 
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // buttonEnableContacts
             // 
             this.buttonEnableContacts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonEnableContacts.Location = new System.Drawing.Point(11, 138);
-            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonEnableContacts.Location = new System.Drawing.Point(15, 201);
+            this.buttonEnableContacts.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonEnableContacts.Name = "buttonEnableContacts";
-            this.buttonEnableContacts.Size = new System.Drawing.Size(182, 36);
+            this.buttonEnableContacts.Size = new System.Drawing.Size(242, 44);
             this.buttonEnableContacts.TabIndex = 20;
             this.buttonEnableContacts.Text = "Enable Selected Electrodes";
             this.toolTip.SetToolTip(this.buttonEnableContacts, "Click and drag to select electrodes in the probe view. \r\nPress this button to ena" +
         "ble the selected electrodes. \r\nNot all electrode combinations are possible.");
             this.buttonEnableContacts.UseVisualStyleBackColor = true;
-            this.buttonEnableContacts.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonEnableContacts.Click += new System.EventHandler(this.EnableContacts_Click);
             // 
             // buttonClearSelections
             // 
             this.buttonClearSelections.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonClearSelections.Location = new System.Drawing.Point(11, 178);
-            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonClearSelections.Location = new System.Drawing.Point(15, 250);
+            this.buttonClearSelections.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonClearSelections.Name = "buttonClearSelections";
-            this.buttonClearSelections.Size = new System.Drawing.Size(182, 36);
+            this.buttonClearSelections.Size = new System.Drawing.Size(242, 44);
             this.buttonClearSelections.TabIndex = 19;
             this.buttonClearSelections.Text = "Clear Electrode Selection";
             this.toolTip.SetToolTip(this.buttonClearSelections, "Deselect all electrodes in the probe view. \r\nNote that this does not disable elec" +
         "trodes, but simply deselects them.");
             this.buttonClearSelections.UseVisualStyleBackColor = true;
-            this.buttonClearSelections.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonClearSelections.Click += new System.EventHandler(this.ClearSelection_Click);
             // 
             // buttonResetZoom
             // 
             this.buttonResetZoom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonResetZoom.Location = new System.Drawing.Point(11, 218);
-            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonResetZoom.Location = new System.Drawing.Point(15, 299);
+            this.buttonResetZoom.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonResetZoom.Name = "buttonResetZoom";
-            this.buttonResetZoom.Size = new System.Drawing.Size(182, 36);
+            this.buttonResetZoom.Size = new System.Drawing.Size(242, 44);
             this.buttonResetZoom.TabIndex = 4;
             this.buttonResetZoom.Text = "Reset Zoom";
             this.toolTip.SetToolTip(this.buttonResetZoom, "Reset the zoom in the probe view so that the probe is zoomed out and centered.");
             this.buttonResetZoom.UseVisualStyleBackColor = true;
-            this.buttonResetZoom.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonResetZoom.Click += new System.EventHandler(this.ResetZoom_Click);
             // 
             // buttonChooseCalibrationFile
             // 
             this.buttonChooseCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonChooseCalibrationFile.Location = new System.Drawing.Point(169, 24);
-            this.buttonChooseCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonChooseCalibrationFile.Location = new System.Drawing.Point(220, 30);
+            this.buttonChooseCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonChooseCalibrationFile.Name = "buttonChooseCalibrationFile";
-            this.buttonChooseCalibrationFile.Size = new System.Drawing.Size(28, 20);
+            this.buttonChooseCalibrationFile.Size = new System.Drawing.Size(37, 25);
             this.buttonChooseCalibrationFile.TabIndex = 34;
             this.buttonChooseCalibrationFile.Text = "...";
             this.toolTip.SetToolTip(this.buttonChooseCalibrationFile, "Browse for a gain calibration file.");
             this.buttonChooseCalibrationFile.UseVisualStyleBackColor = true;
-            this.buttonChooseCalibrationFile.Click += new System.EventHandler(this.ButtonClick);
+            this.buttonChooseCalibrationFile.Click += new System.EventHandler(this.ChooseCalibrationFile_Click);
             // 
             // panelProbe
             // 
             this.panelProbe.AutoSize = true;
             this.panelProbe.Controls.Add(this.panelTrackBar);
             this.panelProbe.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelProbe.Location = new System.Drawing.Point(2, 2);
-            this.panelProbe.Margin = new System.Windows.Forms.Padding(2);
+            this.panelProbe.Location = new System.Drawing.Point(3, 2);
+            this.panelProbe.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelProbe.Name = "panelProbe";
-            this.panelProbe.Size = new System.Drawing.Size(621, 463);
+            this.panelProbe.Size = new System.Drawing.Size(828, 555);
             this.panelProbe.TabIndex = 1;
             // 
             // panelTrackBar
@@ -213,9 +232,10 @@
             this.panelTrackBar.Controls.Add(label6);
             this.panelTrackBar.Controls.Add(label7);
             this.panelTrackBar.Controls.Add(this.trackBarProbePosition);
-            this.panelTrackBar.Location = new System.Drawing.Point(581, 6);
+            this.panelTrackBar.Location = new System.Drawing.Point(775, -1);
+            this.panelTrackBar.Margin = new System.Windows.Forms.Padding(4);
             this.panelTrackBar.Name = "panelTrackBar";
-            this.panelTrackBar.Size = new System.Drawing.Size(37, 454);
+            this.panelTrackBar.Size = new System.Drawing.Size(49, 559);
             this.panelTrackBar.TabIndex = 30;
             // 
             // trackBarProbePosition
@@ -223,12 +243,12 @@
             this.trackBarProbePosition.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.trackBarProbePosition.AutoSize = false;
-            this.trackBarProbePosition.Location = new System.Drawing.Point(-6, 9);
-            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(2);
+            this.trackBarProbePosition.Location = new System.Drawing.Point(-8, 11);
+            this.trackBarProbePosition.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.trackBarProbePosition.Maximum = 100;
             this.trackBarProbePosition.Name = "trackBarProbePosition";
             this.trackBarProbePosition.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBarProbePosition.Size = new System.Drawing.Size(37, 435);
+            this.trackBarProbePosition.Size = new System.Drawing.Size(49, 535);
             this.trackBarProbePosition.TabIndex = 22;
             this.trackBarProbePosition.TickFrequency = 2;
             this.trackBarProbePosition.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
@@ -240,6 +260,8 @@
             this.panelChannelOptions.AutoSize = true;
             this.panelChannelOptions.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.panelChannelOptions.BackColor = System.Drawing.SystemColors.ControlLightLight;
+            this.panelChannelOptions.Controls.Add(this.textBoxGainCorrection);
+            this.panelChannelOptions.Controls.Add(label1);
             this.panelChannelOptions.Controls.Add(this.buttonChooseCalibrationFile);
             this.panelChannelOptions.Controls.Add(this.textBoxProbeCalibrationFile);
             this.panelChannelOptions.Controls.Add(probeCalibrationFile);
@@ -251,20 +273,31 @@
             this.panelChannelOptions.Controls.Add(this.buttonClearSelections);
             this.panelChannelOptions.Controls.Add(this.buttonResetZoom);
             this.panelChannelOptions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelChannelOptions.Location = new System.Drawing.Point(627, 2);
-            this.panelChannelOptions.Margin = new System.Windows.Forms.Padding(2);
+            this.panelChannelOptions.Location = new System.Drawing.Point(837, 2);
+            this.panelChannelOptions.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.panelChannelOptions.Name = "panelChannelOptions";
-            this.panelChannelOptions.Size = new System.Drawing.Size(205, 463);
+            this.panelChannelOptions.Size = new System.Drawing.Size(272, 555);
             this.panelChannelOptions.TabIndex = 1;
+            // 
+            // textBoxGainCorrection
+            // 
+            this.textBoxGainCorrection.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBoxGainCorrection.Location = new System.Drawing.Point(106, 68);
+            this.textBoxGainCorrection.Name = "textBoxGainCorrection";
+            this.textBoxGainCorrection.ReadOnly = true;
+            this.textBoxGainCorrection.Size = new System.Drawing.Size(151, 22);
+            this.textBoxGainCorrection.TabIndex = 36;
+            this.textBoxGainCorrection.TabStop = false;
             // 
             // textBoxProbeCalibrationFile
             // 
             this.textBoxProbeCalibrationFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxProbeCalibrationFile.Location = new System.Drawing.Point(11, 24);
-            this.textBoxProbeCalibrationFile.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxProbeCalibrationFile.Location = new System.Drawing.Point(15, 30);
+            this.textBoxProbeCalibrationFile.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBoxProbeCalibrationFile.Name = "textBoxProbeCalibrationFile";
-            this.textBoxProbeCalibrationFile.Size = new System.Drawing.Size(154, 20);
+            this.textBoxProbeCalibrationFile.Size = new System.Drawing.Size(197, 22);
             this.textBoxProbeCalibrationFile.TabIndex = 33;
             this.textBoxProbeCalibrationFile.TextChanged += new System.EventHandler(this.FileTextChanged);
             // 
@@ -274,10 +307,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxReference.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxReference.FormattingEnabled = true;
-            this.comboBoxReference.Location = new System.Drawing.Point(78, 58);
-            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBoxReference.Location = new System.Drawing.Point(106, 109);
+            this.comboBoxReference.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxReference.Name = "comboBoxReference";
-            this.comboBoxReference.Size = new System.Drawing.Size(115, 21);
+            this.comboBoxReference.Size = new System.Drawing.Size(151, 24);
             this.comboBoxReference.TabIndex = 31;
             // 
             // comboBoxChannelPresets
@@ -286,10 +319,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxChannelPresets.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxChannelPresets.FormattingEnabled = true;
-            this.comboBoxChannelPresets.Location = new System.Drawing.Point(78, 97);
-            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(2);
+            this.comboBoxChannelPresets.Location = new System.Drawing.Point(106, 150);
+            this.comboBoxChannelPresets.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.comboBoxChannelPresets.Name = "comboBoxChannelPresets";
-            this.comboBoxChannelPresets.Size = new System.Drawing.Size(115, 21);
+            this.comboBoxChannelPresets.Size = new System.Drawing.Size(151, 24);
             this.comboBoxChannelPresets.TabIndex = 24;
             // 
             // buttonCancel
@@ -297,27 +330,26 @@
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(726, 2);
-            this.buttonCancel.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonCancel.Location = new System.Drawing.Point(990, 2);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.Size = new System.Drawing.Size(100, 30);
+            this.buttonCancel.Size = new System.Drawing.Size(111, 34);
             this.buttonCancel.TabIndex = 1;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
-            this.buttonCancel.Click += new System.EventHandler(this.ButtonClick);
             // 
             // buttonOkay
             // 
             this.buttonOkay.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOkay.Location = new System.Drawing.Point(622, 2);
-            this.buttonOkay.Margin = new System.Windows.Forms.Padding(2);
+            this.buttonOkay.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.buttonOkay.Location = new System.Drawing.Point(873, 2);
+            this.buttonOkay.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonOkay.Name = "buttonOkay";
-            this.buttonOkay.Size = new System.Drawing.Size(100, 30);
+            this.buttonOkay.Size = new System.Drawing.Size(111, 34);
             this.buttonOkay.TabIndex = 0;
             this.buttonOkay.Text = "OK";
             this.buttonOkay.UseVisualStyleBackColor = true;
-            this.buttonOkay.Click += new System.EventHandler(this.ButtonClick);
             // 
             // tableLayoutPanel1
             // 
@@ -330,12 +362,14 @@
             this.tableLayoutPanel1.Controls.Add(this.panelProbe, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 24);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 26);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 42F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(834, 509);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 45F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1112, 604);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
             // flowLayoutPanel1
@@ -345,22 +379,43 @@
             this.flowLayoutPanel1.Controls.Add(this.buttonOkay);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 470);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 563);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(828, 36);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1104, 37);
             this.flowLayoutPanel1.TabIndex = 2;
+            // 
+            // statusStrip1
+            // 
+            this.statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            toolStripLabelGainCalibrationSN,
+            this.toolStripGainCalSN});
+            this.statusStrip1.Location = new System.Drawing.Point(0, 630);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(1112, 26);
+            this.statusStrip1.TabIndex = 3;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
+            // toolStripGainCalSN
+            // 
+            this.toolStripGainCalSN.AutoSize = false;
+            this.toolStripGainCalSN.Name = "toolStripGainCalSN";
+            this.toolStripGainCalSN.Size = new System.Drawing.Size(120, 20);
+            this.toolStripGainCalSN.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // NeuropixelsV2eProbeConfigurationDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(834, 533);
+            this.ClientSize = new System.Drawing.Size(1112, 656);
             this.Controls.Add(this.tableLayoutPanel1);
+            this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.menuStrip);
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip;
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "NeuropixelsV2eProbeConfigurationDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "NeuropixelsV2e Probe Configuration";
@@ -375,6 +430,8 @@
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -400,5 +457,8 @@
         private System.Windows.Forms.Button buttonResetZoom;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.TextBox textBoxGainCorrection;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripGainCalSN;
     }
 }

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -522,14 +522,12 @@ namespace OpenEphys.Onix1.Design
             }
             catch (IOException ex)
             {
-                MessageBox.Show($"An I/O error occurred while parsing {textBoxProbeCalibrationFile.Text}. Check the error log below." +
-                    $"\n\n" + ex.Message);
+                MessageBox.Show(ex.Message, "I/O error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
             catch (UnauthorizedAccessException ex)
             {
-                MessageBox.Show($"An unauthorized access error occurred while parsing {textBoxProbeCalibrationFile.Text}. Check the error log below." +
-                    $"\n\n" + ex.Message);
+                MessageBox.Show(ex.Message, "Unauthorized access error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -550,7 +548,10 @@ namespace OpenEphys.Onix1.Design
             {
                 CheckFileExists = true,
                 Filter = "Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv|All Files|*.*",
-                FilterIndex = 0
+                FilterIndex = 0,
+                InitialDirectory = File.Exists(textBoxProbeCalibrationFile.Text) ? 
+                                   Path.GetDirectoryName(textBoxProbeCalibrationFile.Text) : 
+                                   ""
             };
 
             if (ofd.ShowDialog() == DialogResult.OK)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using System.Drawing;
+using System.IO;
 
 namespace OpenEphys.Onix1.Design
 {
@@ -78,18 +78,18 @@ namespace OpenEphys.Onix1.Design
             panelProbe.Controls.Add(ChannelConfiguration);
             this.AddMenuItemsFromDialogToFileOption(ChannelConfiguration);
 
-            panelProbe.Visible = IsProbeCalibrationFileValid(textBoxProbeCalibrationFile.Text);
-
             ChannelConfiguration.OnZoom += UpdateTrackBarLocation;
             ChannelConfiguration.OnFileLoad += OnFileLoadEvent;
 
             comboBoxReference.DataSource = Enum.GetValues(typeof(NeuropixelsV2QuadShankReference));
             comboBoxReference.SelectedItem = ProbeConfiguration.Reference;
-            comboBoxReference.SelectedIndexChanged += SelectedIndexChanged;
+            comboBoxReference.SelectedIndexChanged += SelectedReferenceChanged;
 
             comboBoxChannelPresets.DataSource = Enum.GetValues(typeof(ChannelPreset));
-            comboBoxChannelPresets.SelectedIndexChanged += SelectedIndexChanged;
+            comboBoxChannelPresets.SelectedIndexChanged += SelectedChannelPresetChanged;
             CheckForExistingChannelPreset();
+
+            CheckStatus();
 
             Text += ": " + ProbeConfiguration.Probe.ToString();
         }
@@ -118,20 +118,18 @@ namespace OpenEphys.Onix1.Design
             }
         }
 
-        private void SelectedIndexChanged(object sender, EventArgs e)
+        private void SelectedReferenceChanged(object sender, EventArgs e)
         {
-            var comboBox = sender as ComboBox;
+            ProbeConfiguration.Reference = (NeuropixelsV2QuadShankReference)((ComboBox)sender).SelectedItem;
+        }
 
-            if (comboBox.Name == nameof(comboBoxReference))
+        private void SelectedChannelPresetChanged(object sender, EventArgs e)
+        {
+            var channelPreset = (ChannelPreset)((ComboBox)sender).SelectedItem;
+
+            if (channelPreset != ChannelPreset.None)
             {
-                ProbeConfiguration.Reference = (NeuropixelsV2QuadShankReference)comboBox.SelectedItem;
-            }
-            else if (comboBox.Name == nameof(comboBoxChannelPresets))
-            {
-                if ((ChannelPreset)comboBox.SelectedItem != ChannelPreset.None)
-                {
-                    SetChannelPreset((ChannelPreset)comboBox.SelectedItem);
-                }
+                SetChannelPreset(channelPreset);
             }
         }
 
@@ -505,76 +503,78 @@ namespace OpenEphys.Onix1.Design
         private void OnFileLoadEvent(object sender, EventArgs e)
         {
             // NB: Ensure that the newly loaded ProbeConfiguration in the ChannelConfigurationDialog is reflected here.
-            ProbeConfiguration = ChannelConfiguration.ProbeConfiguration; 
+            ProbeConfiguration = ChannelConfiguration.ProbeConfiguration;
             CheckForExistingChannelPreset();
         }
 
         private void FileTextChanged(object sender, EventArgs e)
         {
-            if (sender is TextBox textBox && textBox != null && textBox.Name == nameof(textBoxProbeCalibrationFile))
-            {
-                panelProbe.Visible = IsProbeCalibrationFileValid(textBoxProbeCalibrationFile.Text);
-            }
+            CheckStatus();
         }
 
-        private bool IsProbeCalibrationFileValid(string file)
+        private void CheckStatus()
         {
-            if (string.IsNullOrEmpty(file))
-                return false;
+            NeuropixelsV2GainCorrection? gainCorrection;
 
-            return File.Exists(file);
+            try
+            {
+                gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(textBoxProbeCalibrationFile.Text);
+            }
+            catch (IOException ex)
+            {
+                MessageBox.Show($"An I/O error occurred while parsing {textBoxProbeCalibrationFile.Text}. Check the error log below." +
+                    $"\n\n" + ex.Message);
+                return;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                MessageBox.Show($"An unauthorized access error occurred while parsing {textBoxProbeCalibrationFile.Text}. Check the error log below." +
+                    $"\n\n" + ex.Message);
+                return;
+            }
+
+            panelProbe.Visible = gainCorrection.HasValue;
+
+            textBoxGainCorrection.Text = gainCorrection.HasValue
+                                         ? gainCorrection.Value.GainCorrectionFactor.ToString()
+                                         : "";
+
+            toolStripGainCalSN.Text = gainCorrection.HasValue
+                                     ? gainCorrection.Value.SerialNumber.ToString()
+                                     : string.IsNullOrEmpty(textBoxProbeCalibrationFile.Text) ? "No file found." : "Invalid file.";
         }
 
-        internal void ButtonClick(object sender, EventArgs e)
+        internal void ChooseCalibrationFile_Click(object sender, EventArgs e)
         {
-            if (sender is Button button && button != null)
+            var ofd = new OpenFileDialog()
             {
-                if (button.Name == nameof(buttonOkay))
-                {
-                    DialogResult = DialogResult.OK;
-                }
-                else if (button.Name == nameof(buttonChooseCalibrationFile))
-                {
-                    var ofd = new OpenFileDialog()
-                    {
-                        CheckFileExists = true,
-                        Filter = "Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv|All Files|*.*",
-                        FilterIndex = 0
-                    };
+                CheckFileExists = true,
+                Filter = "Gain calibration files (*_gainCalValues.csv)|*_gainCalValues.csv|All Files|*.*",
+                FilterIndex = 0
+            };
 
-                    if (ofd.ShowDialog() == DialogResult.OK)
-                    {
-                        textBoxProbeCalibrationFile.Text = ofd.FileName;
-                        panelProbe.Visible = IsProbeCalibrationFileValid(textBoxProbeCalibrationFile.Text);
-                    }
-                    else
-                    {
-                        panelProbe.Visible = IsProbeCalibrationFileValid(textBoxProbeCalibrationFile.Text);
-                    }
-                }
-                else if (button.Name == nameof(buttonResetZoom))
-                {
-                    ResetZoom();
-                }
-                else if (button.Name == nameof(buttonClearSelections))
-                {
-                    ChannelConfiguration.SetAllSelections(false);
-                    ChannelConfiguration.HighlightEnabledContacts();
-                    ChannelConfiguration.HighlightSelectedContacts();
-                    ChannelConfiguration.UpdateContactLabels();
-                    ChannelConfiguration.RefreshZedGraph();
-                }
-                else if (button.Name == nameof(buttonEnableContacts))
-                {
-                    EnableSelectedContacts();
-
-                    ChannelConfiguration.SetAllSelections(false);
-                    ChannelConfiguration.HighlightEnabledContacts();
-                    ChannelConfiguration.HighlightSelectedContacts();
-                    ChannelConfiguration.UpdateContactLabels();
-                    ChannelConfiguration.RefreshZedGraph();
-                }
+            if (ofd.ShowDialog() == DialogResult.OK)
+            {
+                textBoxProbeCalibrationFile.Text = ofd.FileName;
             }
+
+            CheckStatus();
+        }
+
+        internal void ResetZoom_Click(object sender, EventArgs e)
+        {
+            ResetZoom();
+        }
+
+        internal void ClearSelection_Click(object sender, EventArgs e)
+        {
+            DeselectContacts();
+        }
+
+        internal void EnableContacts_Click(object sender, EventArgs e)
+        {
+            EnableSelectedContacts();
+            DeselectContacts();
         }
 
         private void EnableSelectedContacts()
@@ -587,6 +587,15 @@ namespace OpenEphys.Onix1.Design
             ChannelConfiguration.EnableElectrodes(selectedElectrodes);
 
             CheckForExistingChannelPreset();
+        }
+
+        private void DeselectContacts()
+        {
+            ChannelConfiguration.SetAllSelections(false);
+            ChannelConfiguration.HighlightEnabledContacts();
+            ChannelConfiguration.HighlightSelectedContacts();
+            ChannelConfiguration.UpdateContactLabels();
+            ChannelConfiguration.RefreshZedGraph();
         }
 
         private void ResetZoom()
@@ -604,13 +613,8 @@ namespace OpenEphys.Onix1.Design
 
         private void TrackBarScroll(object sender, EventArgs e)
         {
-            if (sender is TrackBar trackBar && trackBar != null)
-            {
-                if (trackBar.Name == nameof(trackBarProbePosition))
-                {
-                    MoveToVerticalPosition((float)trackBar.Value / trackBar.Maximum);
-                }
-            }
+            var trackBar = (TrackBar)sender;
+            MoveToVerticalPosition((float)trackBar.Value / trackBar.Maximum);
         }
 
         private void UpdateTrackBarLocation(object sender, EventArgs e)

--- a/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.resx
+++ b/OpenEphys.Onix1.Design/NeuropixelsV2eProbeConfigurationDialog.resx
@@ -132,11 +132,20 @@
   <metadata name="labelPresets.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
+  <metadata name="label1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <metadata name="toolStripLabelGainCalibrationSN.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
   <metadata name="menuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>274, 17</value>
+  </metadata>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>382, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2e.cs
@@ -161,8 +161,21 @@ namespace OpenEphys.Onix1
                 // configure probe A streaming
                 if (probeAMetadata.ProbeSerialNumber != null)
                 {
-                    gainCorrectionA = NeuropixelsV2.ReadGainCorrection(
-                        GainCalibrationFileA, (ulong)probeAMetadata.ProbeSerialNumber, NeuropixelsV2Probe.ProbeA);
+                    var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(GainCalibrationFileA);
+
+                    if (!gainCorrection.HasValue)
+                    {
+                        throw new ArgumentException($"{NeuropixelsV2Probe.ProbeA}'s calibration file \"{GainCalibrationFileA}\" is invalid.");
+                    }
+
+                    if (gainCorrection.Value.SerialNumber != probeAMetadata.ProbeSerialNumber)
+                    {
+                        throw new ArgumentException($"The probe serial number ({probeAMetadata.ProbeSerialNumber}) does not " +
+                            $"match the gain calibration file serial number: {gainCorrection.Value.SerialNumber}.");
+                    }
+
+                    gainCorrectionA = gainCorrection.Value.GainCorrectionFactor;
+
                     SelectProbe(serializer, NeuropixelsV2e.ProbeASelected);
                     probeControl.WriteConfiguration(ProbeConfigurationA);
                     ConfigureProbeStreaming(probeControl);
@@ -171,8 +184,21 @@ namespace OpenEphys.Onix1
                 // configure probe B streaming
                 if (probeBMetadata.ProbeSerialNumber != null)
                 {
-                    gainCorrectionB = NeuropixelsV2.ReadGainCorrection(
-                        GainCalibrationFileB, (ulong)probeBMetadata.ProbeSerialNumber, NeuropixelsV2Probe.ProbeB);
+                    var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(GainCalibrationFileB);
+
+                    if (!gainCorrection.HasValue)
+                    {
+                        throw new ArgumentException($"{NeuropixelsV2Probe.ProbeB}'s calibration file \"{GainCalibrationFileB}\" is invalid.");
+                    }
+
+                    if (gainCorrection.Value.SerialNumber != probeBMetadata.ProbeSerialNumber)
+                    {
+                        throw new ArgumentException($"The probe serial number ({probeBMetadata.ProbeSerialNumber}) does not " +
+                            $"match the gain calibration file serial number: {gainCorrection.Value.SerialNumber}.");
+                    }
+
+                    gainCorrectionB = gainCorrection.Value.GainCorrectionFactor;
+
                     SelectProbe(serializer, NeuropixelsV2e.ProbeBSelected);
                     probeControl.WriteConfiguration(ProbeConfigurationB);
                     ConfigureProbeStreaming(probeControl);

--- a/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix1/ConfigureNeuropixelsV2eBeta.cs
@@ -182,9 +182,21 @@ namespace OpenEphys.Onix1
                 // configure probe A streaming
                 if (probeAMetadata.ProbeSerialNumber != null)
                 {
-                    // read gain correction
-                    gainCorrectionA = NeuropixelsV2.ReadGainCorrection(
-                        GainCalibrationFileA, (ulong)probeAMetadata.ProbeSerialNumber, NeuropixelsV2Probe.ProbeA);
+                    var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(GainCalibrationFileA);
+
+                    if (!gainCorrection.HasValue)
+                    {
+                        throw new ArgumentException($"{NeuropixelsV2Probe.ProbeA}'s calibration file \"{GainCalibrationFileA}\" is invalid.");
+                    }
+
+                    if (gainCorrection.Value.SerialNumber != probeAMetadata.ProbeSerialNumber)
+                    {
+                        throw new ArgumentException($"The probe serial number ({probeAMetadata.ProbeSerialNumber}) does not " +
+                            $"match the gain calibration file serial number: {gainCorrection.Value.SerialNumber}.");
+                    }
+
+                    gainCorrectionA = gainCorrection.Value.GainCorrectionFactor;
+
                     SelectProbe(serializer, ref gpo32Config, NeuropixelsV2eBeta.SelectProbeA);
                     probeControl.WriteConfiguration(ProbeConfigurationA);
                     ConfigureProbeStreaming(probeControl);
@@ -193,8 +205,21 @@ namespace OpenEphys.Onix1
                 // configure probe B streaming
                 if (probeAMetadata.ProbeSerialNumber != null)
                 {
-                    gainCorrectionB = NeuropixelsV2.ReadGainCorrection(
-                        GainCalibrationFileB, (ulong)probeBMetadata.ProbeSerialNumber, NeuropixelsV2Probe.ProbeB);
+                    var gainCorrection = NeuropixelsV2Helper.TryParseGainCalibrationFile(GainCalibrationFileB);
+
+                    if (!gainCorrection.HasValue)
+                    {
+                        throw new ArgumentException($"{NeuropixelsV2Probe.ProbeB}'s calibration file \"{GainCalibrationFileB}\" is invalid.");
+                    }
+
+                    if (gainCorrection.Value.SerialNumber != probeBMetadata.ProbeSerialNumber)
+                    {
+                        throw new ArgumentException($"The probe serial number ({probeBMetadata.ProbeSerialNumber}) does not " +
+                            $"match the gain calibration file serial number: {gainCorrection.Value.SerialNumber}.");
+                    }
+
+                    gainCorrectionB = gainCorrection.Value.GainCorrectionFactor;
+
                     SelectProbe(serializer, ref gpo32Config, NeuropixelsV2eBeta.SelectProbeB);
                     probeControl.WriteConfiguration(ProbeConfigurationB);
                     ConfigureProbeStreaming(probeControl);

--- a/OpenEphys.Onix1/IsExternalInit.cs
+++ b/OpenEphys.Onix1/IsExternalInit.cs
@@ -1,0 +1,4 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}

--- a/OpenEphys.Onix1/NeuropixelsV1Helper.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1Helper.cs
@@ -9,7 +9,164 @@ namespace OpenEphys.Onix1
     /// </summary>
     public static class NeuropixelsV1Helper
     {
-        internal const int NumberOfGains = 8;
+        internal const int NumberOfGainFactors = 8;
+        internal const int NumberOfAdcParameters = 8;
+
+        /// <summary>
+        /// Tries to parse the ADC calibration file.
+        /// </summary>
+        /// <remarks>
+        /// Checks if the given filename points to a real file, and checks each individual element:
+        /// <para>
+        /// 1) Serial number as the first line.
+        /// </para>
+        /// <para>
+        /// 2) All remaining lines (32 lines) contain the ADC correction values for each ADC. First is the ADC number,
+        /// followed by the <see cref="NeuropixelsV1eAdc"/> values. All elements are separated by commas, and each element is a valid 
+        /// integer value.
+        /// </para>
+        /// </remarks>
+        /// <param name="adcCalibrationFile">String defining the path to the ADC calibration file.</param>
+        /// <returns><see cref="NeuropixelsV1eAdcCalibration"/> object that contains the ADC calibration values. This object is null if the file was not successfully parsed.</returns>
+        public static NeuropixelsV1eAdcCalibration? TryParseAdcCalibrationFile(string adcCalibrationFile)
+        {
+            if (!File.Exists(adcCalibrationFile)) return null;
+
+            var lines = File.ReadLines(adcCalibrationFile);
+
+            if (lines.Count() != NeuropixelsV1e.AdcCount + 1) return null;
+            if (!ulong.TryParse(lines.ElementAt(0), out var serialNumber)) return null;
+
+            if (!lines
+                .Skip(1)
+                .Select(l =>
+                {
+                    var ok = int.TryParse(l.Split(',')[0], out int adcNumber);
+                    return (Ok: ok, AdcNumber: adcNumber);
+                })
+                .Where(l => l.Ok)
+                .Select(l => l.AdcNumber)
+                .SequenceEqual(Enumerable.Range(0, NeuropixelsV1e.AdcCount))) return null;
+
+            var adcs = lines
+                       .Skip(1)
+                       .Select(l =>
+                       {
+                           var calibrationValues = l
+                                                   .Split(',')
+                                                   .Skip(1)
+                                                   .Select(p =>
+                                                   {
+                                                       var ok = int.TryParse(p, out int param);
+                                                       return (Ok: ok, Param: param);
+                                                   })
+                                                   .Where(l => l.Ok)
+                                                   .Select(l => l.Param);
+
+                           return calibrationValues.Count() == NumberOfAdcParameters
+                           ? null
+                           : new NeuropixelsV1eAdc {
+                               CompP = calibrationValues.ElementAt(0),
+                               CompN = calibrationValues.ElementAt(1),
+                               Slope = calibrationValues.ElementAt(2),
+                               Coarse = calibrationValues.ElementAt(3),
+                               Fine = calibrationValues.ElementAt(4),
+                               Cfix = calibrationValues.ElementAt(5),
+                               Offset = calibrationValues.ElementAt(6),
+                               Threshold = calibrationValues.ElementAt(7)
+                           };
+                       });
+
+            return adcs.Any(adc => adc == null) ? null : new(serialNumber, adcs.ToArray());
+        }
+
+        /// <summary>
+        /// Tries to parse the gain calibration file.
+        /// </summary>
+        /// <remarks>
+        /// Checks if the given filename points to a real file, and checks each individual element:
+        /// <para>
+        /// 1) Serial number as the first line.
+        /// </para>
+        /// <para>
+        /// 2) All remaining lines (384 lines) contain the gain correction values for each channel. First is the channel number,
+        /// followed by the <see cref="NeuropixelsV1Gain"/> values. All elements are separated by commas, and each element is a valid 
+        /// double value. After the channel number, the first 8 values are AP gain corrections, related to the spike-band, and the last 8 values
+        /// are LFP gain corrections, for the LFP band.
+        /// </para>
+        /// </remarks>
+        /// <param name="gainCalibrationFile">String defining the path to the gain calibration file.</param>
+        /// <param name="apGain">Current <see cref="NeuropixelsV1Gain"/> for the AP data.</param>
+        /// <param name="lfpGain">Current <see cref="NeuropixelsV1Gain"/> for the LFP data.</param>
+        /// <returns><see cref="NeuropixelsV1eGainCorrection"/> object that contains the AP and LFP gain correction values. This object is null if the file was not successfully parsed.</returns>
+        public static NeuropixelsV1eGainCorrection? TryParseGainCalibrationFile(string gainCalibrationFile, NeuropixelsV1Gain apGain, NeuropixelsV1Gain lfpGain)
+        {
+            if (!File.Exists(gainCalibrationFile)) return null;
+
+            var lines = File.ReadLines(gainCalibrationFile);
+
+            if (lines.Count() != NeuropixelsV1e.ElectrodeCount + 1) return null;
+            if (!ulong.TryParse(lines.ElementAt(0), out var serialNumber)) return null;
+
+            if (!lines
+                .Skip(1)
+                .Select(l =>
+                {
+                    var ok = int.TryParse(l.Split(',')[0], out var channel);
+                    return (Ok: ok, Channel: channel);
+                })
+                .Where(l => l.Ok)
+                .Select(l => l.Channel)
+                .SequenceEqual(Enumerable.Range(0, NeuropixelsV1e.ElectrodeCount))) return null;
+
+            var apIndex = Array.IndexOf(Enum.GetValues(typeof(NeuropixelsV1Gain)), apGain);
+            var apGainCorrections = lines
+                                    .Skip(1)
+                                    .Select<string, double?>(l =>
+                                    {
+                                        var corrections = l
+                                                          .Split(',')
+                                                          .Skip(1)
+                                                          .Select(s =>
+                                                          {
+                                                              var ok = double.TryParse(s, out var correction);
+                                                              return (Ok: ok, Correction: correction);
+                                                          })
+                                                          .Where(l => l.Ok)
+                                                          .Select(l => l.Correction);
+                                    
+                                        return corrections.Count() == NumberOfGainFactors * 2 ? corrections.ElementAt(apIndex) : null;
+                                    })
+                                    .Distinct();
+
+            if (apGainCorrections.Count() == 2) apGainCorrections = apGainCorrections.Where(val => val != 1.0); // NB: Reference contacts are always 1.0. Filter this out.
+
+            var lfpIndex = Array.IndexOf(Enum.GetValues(typeof(NeuropixelsV1Gain)), lfpGain) + NumberOfGainFactors;
+            var lfpGainCorrections = lines
+                                     .Skip(1)
+                                     .Select<string, double?>(l =>
+                                     {
+                                         var corrections = l
+                                                          .Split(',')
+                                                          .Skip(1)
+                                                          .Select(s =>
+                                                          {
+                                                              var ok = double.TryParse(s, out var correction);
+                                                              return (Ok: ok, Correction: correction);
+                                                          })
+                                                          .Where(l => l.Ok)
+                                                          .Select(l => l.Correction);
+
+                                         return corrections.Count() == NumberOfGainFactors * 2 ? corrections.ElementAt(lfpIndex) : null;
+                                     })
+                                     .Distinct();
+
+            if (lfpGainCorrections.Count() == 2) lfpGainCorrections = lfpGainCorrections.Where(val => val != 1.0); // NB: Reference contacts are always 1.0. Filter this out.
+
+            return (apGainCorrections.Count() != 1 || lfpGainCorrections.Count() != 1)
+                   ? null
+                   : new(serialNumber, apGainCorrections.First().Value, lfpGainCorrections.First().Value);
+        }
 
         /// <summary>
         /// Returns the ADC values and serial number from an ADC calibration file for a specific probe.
@@ -18,6 +175,7 @@ namespace OpenEphys.Onix1
         /// <returns>Array of <see cref="NeuropixelsV1eAdc"/> values.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="InvalidOperationException"></exception>
+        [Obsolete("Use TryParseAdcCalibrationFile instead for better validation and parsing.")]
         public static NeuropixelsV1eAdcCalibration ParseAdcCalibrationFile(StreamReader file)
         {
             // TODO: "file" input argument should either be a FileStream or a path string. StreamReader is to
@@ -42,7 +200,7 @@ namespace OpenEphys.Onix1
             for (var i = 0; i < NeuropixelsV1e.AdcCount; i++)
             {
                 var adcCal = file.ReadLine().Split(',').Skip(1);
-                if (adcCal.Count() != NumberOfGains)
+                if (adcCal.Count() != NumberOfAdcParameters)
                 {
                     throw new InvalidOperationException("Incorrectly formatted ADC calibration file.");
                 }
@@ -72,6 +230,7 @@ namespace OpenEphys.Onix1
         /// <returns><see cref="NeuropixelsV1eGainCorrection"/>.</returns>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="InvalidOperationException"></exception>
+        [Obsolete("Use TryParseGainCalibrationFile instead for better validation and parsing.")]
         public static NeuropixelsV1eGainCorrection ParseGainCalibrationFile(StreamReader file, NeuropixelsV1Gain apGain, NeuropixelsV1Gain lfpGain)
         {
             // TODO: "file" input argument should either be a FileStream or a path string. StreamReader is to
@@ -93,7 +252,7 @@ namespace OpenEphys.Onix1
 
             var gainCorrections = file.ReadLine().Split(',').Skip(1);
 
-            if (gainCorrections.Count() != 2 * NumberOfGains)
+            if (gainCorrections.Count() != 2 * NumberOfGainFactors)
                 throw new InvalidOperationException("Incorrectly formatted gain correction calibration file.");
 
             var ap = double.Parse(gainCorrections.ElementAt(Array.IndexOf(Enum.GetValues(typeof(NeuropixelsV1Gain)), apGain)));

--- a/OpenEphys.Onix1/NeuropixelsV1eAdcCalibration.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eAdcCalibration.cs
@@ -3,27 +3,7 @@
     /// <summary>
     /// A struct to hold an array of <see cref="NeuropixelsV1eAdcCalibration"/> values and the serial number needed for each <see cref="ConfigureNeuropixelsV1e"/>.
     /// </summary>
-    public readonly struct NeuropixelsV1eAdcCalibration
-    {
-        /// <summary>
-        /// Gets an array of <see cref="NeuropixelsV1eAdc"/> values.
-        /// </summary>
-        public NeuropixelsV1eAdc[] Adcs { get; }
-
-        /// <summary>
-        /// Gets the serial number found in the ADC calibration file.
-        /// </summary>
-        public ulong SN { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NeuropixelsV1eAdcCalibration"/> struct.
-        /// </summary>
-        /// <param name="sn">Unsigned long value holding the serial number of the probe from the calibration file.</param>
-        /// <param name="adcs">Array of <see cref="NeuropixelsV1eAdc"/> values from the calibration file.</param>
-        public NeuropixelsV1eAdcCalibration(ulong sn, NeuropixelsV1eAdc[] adcs)
-        {
-            SN = sn;
-            Adcs = adcs;
-        }
-    }
+    /// <param name="SerialNumber">The serial number from a calibration file.</param>
+    ///  <param name="Adcs">The ADC calibration values from a calibration file.</param>
+    public readonly record struct NeuropixelsV1eAdcCalibration(ulong SerialNumber, NeuropixelsV1eAdc[] Adcs);
 }

--- a/OpenEphys.Onix1/NeuropixelsV1eGainCorrection.cs
+++ b/OpenEphys.Onix1/NeuropixelsV1eGainCorrection.cs
@@ -3,34 +3,8 @@
     /// <summary>
     /// A struct to hold the two gain correction values (AP and LFP) and the serial number needed for each <see cref="ConfigureNeuropixelsV1e"/>.
     /// </summary>
-    public readonly struct NeuropixelsV1eGainCorrection
-    {
-        /// <summary>
-        /// Gets the serial number found in the gain calibration file.
-        /// </summary>
-        public ulong SN { get; }
-
-        /// <summary>
-        /// Gets the AP gain correction found in the gain calibration file for the appropriate AP gain.
-        /// </summary>
-        public double AP { get; }
-
-        /// <summary>
-        /// Gets the LFP gain correction found in the gain calibration file for the appropriate LFP gain.
-        /// </summary>
-        public double LFP { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NeuropixelsV1eGainCorrection"/> struct.
-        /// </summary>
-        /// <param name="sn">Unsigned long value holding the serial number of the probe from the calibration file.</param>
-        /// <param name="ap">Double holding the AP gain correction as pulled from the gain calibration file.</param>
-        /// <param name="lfp">Double holding the LFP gain correction as pulled from the gain calibration file.</param>
-        public NeuropixelsV1eGainCorrection(ulong sn, double ap, double lfp)
-        {
-            SN = sn;
-            AP = ap;
-            LFP = lfp;
-        }
-    }
+    /// <param name="SerialNumber">The serial number from a calibration file.</param>
+    /// <param name="ApGainCorrectionFactor">The gain correction for the spike-band from a gain calibration file.</param>
+    /// <param name="LfpGainCorrectionFactor">The gain correction for the LFP-band from a gain calibration file.</param>
+    public readonly record struct NeuropixelsV1eGainCorrection(ulong SerialNumber, double ApGainCorrectionFactor, double LfpGainCorrectionFactor);
 }

--- a/OpenEphys.Onix1/NeuropixelsV2.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2.cs
@@ -113,30 +113,6 @@ namespace OpenEphys.Onix1
 
             return baseBits;
         }
-
-        internal static double ReadGainCorrection(string gainCalibrationFile, ulong probeSerialNumber, NeuropixelsV2Probe probe)
-        {
-            if (!File.Exists(gainCalibrationFile) )
-            {
-                throw new ArgumentException($"A calibration file must be specified for {probe} with serial number " +
-                    $"{probeSerialNumber}");
-            }
-
-            var gainFile = new StreamReader(gainCalibrationFile);
-            if(!ulong.TryParse(gainFile.ReadLine(), out ulong sn))
-            {
-                throw new ArgumentException($"The calibration file {gainCalibrationFile} specified for {probe} is " +
-                    $"incorrectly formatted.");
-            }
-
-            if (probeSerialNumber != sn)
-            {
-                throw new ArgumentException($"{probe}'s serial number ({probeSerialNumber}) does not " +
-                    $"match the calibration file serial number: {sn}.");
-            }
-
-            return double.Parse(gainFile.ReadLine());
-        }
     }
 }
 

--- a/OpenEphys.Onix1/NeuropixelsV2GainCorrection.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2GainCorrection.cs
@@ -1,9 +1,4 @@
-﻿namespace System.Runtime.CompilerServices
-{
-    internal static class IsExternalInit { }
-}
-
-namespace OpenEphys.Onix1
+﻿namespace OpenEphys.Onix1
 {
     /// <summary>
     /// A struct to hold the gain correction value and the serial number from a Neuropixels 2.0 gain

--- a/OpenEphys.Onix1/NeuropixelsV2GainCorrection.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2GainCorrection.cs
@@ -1,0 +1,15 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// A struct to hold the gain correction value and the serial number from a Neuropixels 2.0 gain
+    /// calibration file.
+    /// </summary>
+    /// <param name="SerialNumber">The serial number from a calibration file.</param>
+    ///  <param name="GainCorrectionFactor">The gain correction from a gain calibration file.</param>
+    public readonly record struct NeuropixelsV2GainCorrection(ulong SerialNumber, double GainCorrectionFactor);
+}

--- a/OpenEphys.Onix1/NeuropixelsV2Helper.cs
+++ b/OpenEphys.Onix1/NeuropixelsV2Helper.cs
@@ -1,0 +1,61 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace OpenEphys.Onix1
+{
+    /// <summary>
+    /// Static helper class for NeuropixelsV2 methods.
+    /// </summary>
+    public class NeuropixelsV2Helper
+    {
+        /// <summary>
+        /// Tries to parse the gain calibration file.
+        /// </summary>
+        /// <remarks>
+        /// Checks if the given filename points to a real file, and also checks for the following elements:
+        /// <para>
+        /// 1) Serial number as the first line.
+        /// </para>
+        /// <para>
+        /// 2) All remaining lines (384 lines) are an integer and a double value, separated by a comma.
+        /// The integer defines the channel number, and the double is the gain calibration value for that channel.
+        /// </para>
+        /// </remarks>
+        /// <param name="gainCalibrationFile">String containing the path to the gain calibration file.</param>
+        /// <returns><see cref="NeuropixelsV2GainCorrection"/> object that contains the gain correction value. This object is null if the file was not successfully parsed.</returns>
+        public static NeuropixelsV2GainCorrection? TryParseGainCalibrationFile(string gainCalibrationFile)
+        {
+            if (!File.Exists(gainCalibrationFile)) return null;
+
+            var lines = File.ReadLines(gainCalibrationFile);
+
+            if (lines.Count() != NeuropixelsV2.ChannelCount + 1) return null;
+            if (!ulong.TryParse(lines.ElementAt(0), out var serialNumber)) return null;
+
+            if (!lines
+                .Skip(1)
+                .Select(l =>
+                {
+                    var s = l.Split(',')[0];
+                    var ok = int.TryParse(s, out var channel);
+                    return (Ok: ok, Channel: channel);
+                })
+                .Where(l => l.Ok)
+                .Select(l => l.Channel)
+                .SequenceEqual(Enumerable.Range(0, NeuropixelsV2.ChannelCount))) return null;
+
+            var gains = lines
+                        .Skip(1)
+                        .Select(l =>
+                        {
+                            var ok = double.TryParse(l.Split(',')[1], out var gainCorrection);
+                            return (Ok: ok, GainCorrection: gainCorrection);
+                        })
+                        .Where(l => l.Ok)
+                        .Select(l => l.GainCorrection)
+                        .Distinct();
+
+            return gains.Count() == 1 ? new(serialNumber, gains.First()) : null;
+        }
+    }
+}


### PR DESCRIPTION
In this PR, the calibration files for `NeuropixelsV1e`, `NeuropixelsV2e`, and `NeuropixelsV2eBeta` are now validated using a custom `TryParse` method. This applies to the ADC / gain calibration files for `NeuropixelsV1e`, and the gain calibration file for `NeuropixelsV2e`/`NeuropixelsV2eBeta`. 

The `TryParse` method will validate that the file exists and can be opened, that there are the correct number of elements, and that each element is able to be parsed into the correct type. For example, the first line in each file should contain a single element, and it should be `ulong` for the serial number. Other elements include the channel number, gain correction value at different gain levels, or ADC values.

Fixes #228 

Related to #283, existing public methods for `NeuropixelsV1e` have been marked as obsolete, since they took a `StreamReader` as an argument instead of the filepath. These methods are not removed or modified, since doing so would be a major revision.

In addition to creating the `TryParse` method, this PR also takes advantage of these new methods by adding the correction values back into the various dialogs so that the user can view the ADC values and gain corrections that will be applied to the data based on the current gains selected. These are added at all dialog levels, so that anytime a file is selected, the gain will be updated in a textbox. For ADC values, instead of being in a tab like they were previously, they are now opened in a new window when a button is pressed. This window is modal, so the rest of the GUI is nonfunctional until the ADC window is closed. 

Fixes #232 

While adding control elements, including a status bar to display the serial number, there were some small quality-of-life changes made to control sizes.