### PR TITLE
Corrected Rhd2164 XML tags

### DIFF
--- a/OpenEphys.Onix1/Rhd2164Config.cs
+++ b/OpenEphys.Onix1/Rhd2164Config.cs
@@ -252,11 +252,11 @@ namespace OpenEphys.Onix1
         /// </summary>
         Differential = 0,
         /// <summary>
-        /// Specifies 3310 Hz.
+        /// Specifies 3309 Hz.
         /// </summary>
         Dsp3309Hz,
         /// <summary>
-        /// Specifies 1370 Hz.
+        /// Specifies 1374 Hz.
         /// </summary>
         Dsp1374Hz,
         /// <summary>


### PR DESCRIPTION
Upon review, the XML comments for two of the `DspCutoff` enums were incorrect and needed to match the values listed by the enum value itself. 