### PR TITLE
Remove Breakout prefix from classes where its redundant

### DIFF
--- a/OpenEphys.Onix1/AnalogInput.cs
+++ b/OpenEphys.Onix1/AnalogInput.cs
@@ -9,7 +9,8 @@ using OpenCV.Net;
 
 namespace OpenEphys.Onix1
 {
-    [Obsolete]
+    /// <inheritdoc cref = "AnalogInput"/>
+    [Obsolete("Use AnalogInput instead. This operator will be removed in version 1.0.0")]
     public class BreakoutAnalogInput : AnalogInput { }
 
     /// <summary>

--- a/OpenEphys.Onix1/AnalogInputDataFrame.cs
+++ b/OpenEphys.Onix1/AnalogInputDataFrame.cs
@@ -6,15 +6,15 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Buffered analog data produced by the ONIX breakout board.
     /// </summary>
-    public class BreakoutAnalogInputDataFrame : BufferedDataFrame
+    public class AnalogInputDataFrame : BufferedDataFrame
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="BreakoutAnalogInputDataFrame"/> class.
+        /// Initializes a new instance of the <see cref="AnalogInputDataFrame"/> class.
         /// </summary>
         /// <param name="clock">A buffered array of <see cref="DataFrame.Clock"/> values.</param>
         /// <param name="hubClock"> A buffered array of hub clock counter values.</param>
         /// <param name="analogData">A buffered array of multi-channel analog data.</param>
-        public BreakoutAnalogInputDataFrame(ulong[] clock, ulong[] hubClock, Mat analogData)
+        public AnalogInputDataFrame(ulong[] clock, ulong[] hubClock, Mat analogData)
             : base(clock, hubClock)
         {
             AnalogData = analogData;
@@ -27,9 +27,9 @@ namespace OpenEphys.Onix1
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    unsafe struct BreakoutAnalogInputPayload
+    unsafe struct AnalogInputPayload
     {
         public ulong HubClock;
-        public fixed short AnalogData[BreakoutAnalogIO.ChannelCount];
+        public fixed short AnalogData[AnalogIO.ChannelCount];
     }
 }

--- a/OpenEphys.Onix1/AnalogOutput.cs
+++ b/OpenEphys.Onix1/AnalogOutput.cs
@@ -7,20 +7,23 @@ using OpenCV.Net;
 
 namespace OpenEphys.Onix1
 {
+    [Obsolete]
+    public class BreakoutAnalogOutput : AnalogOutput { }
+
     /// <summary>
     /// Sends analog output data to an ONIX breakout board.
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureBreakoutAnalogIO"/>, using a shared <c>DeviceName</c>.
+    /// cref="ConfigureAnalogIO"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Sends analog output data to an ONIX breakout board.")]
-    public class BreakoutAnalogOutput : Sink<Mat>
+    public class AnalogOutput : Sink<Mat>
     {
-        const BreakoutAnalogIOVoltageRange OutputRange = BreakoutAnalogIOVoltageRange.TenVolts;
+        const AnalogIOVoltageRange OutputRange = AnalogIOVoltageRange.TenVolts;
 
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
-        [TypeConverter(typeof(BreakoutAnalogIO.NameConverter))]
+        [TypeConverter(typeof(AnalogIO.NameConverter))]
         [Description(SingleDeviceFactory.DeviceNameDescription)]
         [Category(DeviceFactory.ConfigurationCategory)]
         public string DeviceName { get; set; }
@@ -29,15 +32,15 @@ namespace OpenEphys.Onix1
         /// Gets or sets the data type used to represent analog samples.
         /// </summary>
         /// <remarks>
-        /// If <see cref="BreakoutAnalogIODataType.S16"/> is selected, each DAC value is represented by a
+        /// If <see cref="AnalogIODataType.S16"/> is selected, each DAC value is represented by a
         /// signed, twos-complement encoded 16-bit integer. In this case, the output voltage always
-        /// corresponds to <see cref="BreakoutAnalogIOVoltageRange.TenVolts"/>. When <see
-        /// cref="BreakoutAnalogIODataType.Volts"/> is selected, 32-bit floating point voltages between -10
+        /// corresponds to <see cref="AnalogIOVoltageRange.TenVolts"/>. When <see
+        /// cref="AnalogIODataType.Volts"/> is selected, 32-bit floating point voltages between -10
         /// and 10 volts are sent directly to the DACs.
         /// </remarks>
         [Description("The data type used to represent analog samples.")]
         [Category(DeviceFactory.ConfigurationCategory)]
-        public BreakoutAnalogIODataType DataType { get; set; } = BreakoutAnalogIODataType.S16;
+        public AnalogIODataType DataType { get; set; } = AnalogIODataType.S16;
 
         /// <summary>
         /// Send an matrix of samples to all enabled analog outputs.
@@ -45,8 +48,8 @@ namespace OpenEphys.Onix1
         /// <remarks>
         /// If a matrix contains multiple samples, they will be written to hardware as quickly as
         /// communication allows. The data within each input matrix must have <see cref="Depth.S16"/> when
-        /// <c>DataType</c> is set to <see cref="BreakoutAnalogIODataType.S16"/> or <see cref="Depth.F32"/>
-        /// when <c>DataType</c> is set to <see cref="BreakoutAnalogIODataType.Volts"/>.
+        /// <c>DataType</c> is set to <see cref="AnalogIODataType.S16"/> or <see cref="Depth.F32"/>
+        /// when <c>DataType</c> is set to <see cref="AnalogIODataType.Volts"/>.
         /// </remarks>
         /// <param name="source"> A sequence of 12xN sample matrices containing the analog data to write to
         /// channels 0 to 11.</param>
@@ -60,14 +63,14 @@ namespace OpenEphys.Onix1
                 var bufferSize = 0;
                 var scaleBuffer = default(Mat);
                 var transposeBuffer = default(Mat);
-                var sampleScale = dataType == BreakoutAnalogIODataType.Volts
-                    ? 1 / BreakoutAnalogIODeviceInfo.GetVoltsPerDivision(OutputRange)
+                var sampleScale = dataType == AnalogIODataType.Volts
+                    ? 1 / AnalogIODeviceInfo.GetVoltsPerDivision(OutputRange)
                     : 1;
-                var device = deviceInfo.GetDeviceContext(typeof(BreakoutAnalogIO));
+                var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
                 return source.Do(data =>
                 {
-                    if (dataType == BreakoutAnalogIODataType.S16 && data.Depth != Depth.S16 ||
-                        dataType == BreakoutAnalogIODataType.Volts && data.Depth != Depth.F32)
+                    if (dataType == AnalogIODataType.S16 && data.Depth != Depth.S16 ||
+                        dataType == AnalogIODataType.Volts && data.Depth != Depth.F32)
                     {
                         ThrowDataTypeException(data.Depth);
                     }
@@ -116,7 +119,7 @@ namespace OpenEphys.Onix1
         /// </summary>
         /// <remarks>
         /// This overload should be used when <c>DataType</c> is set to <see
-        /// cref="BreakoutAnalogIODataType.S16"/> and values should be within -32,768 to 32,767, which
+        /// cref="AnalogIODataType.S16"/> and values should be within -32,768 to 32,767, which
         /// correspond to -10.0 to 10.0 volts.
         /// </remarks>
         /// <param name="source"> A sequence of 12x1 element arrays each containing the analog data to write
@@ -125,12 +128,12 @@ namespace OpenEphys.Onix1
         /// to 11.</returns>
         public IObservable<short[]> Process(IObservable<short[]> source)
         {
-            if (DataType != BreakoutAnalogIODataType.S16)
+            if (DataType != AnalogIODataType.S16)
                 ThrowDataTypeException(Depth.S16);
 
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
-                var device = deviceInfo.GetDeviceContext(typeof(BreakoutAnalogIO));
+                var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
                 return source.Do(data =>
                 {
                     AssertChannelCount(data.Length);
@@ -150,7 +153,7 @@ namespace OpenEphys.Onix1
         /// </summary>
         /// <remarks>
         /// This overload should be used when <c>DataType</c> is set to <see
-        /// cref="BreakoutAnalogIODataType.Volts"/> and values should be within -10.0 to 10.0 volts.
+        /// cref="AnalogIODataType.Volts"/> and values should be within -10.0 to 10.0 volts.
         /// </remarks>
         /// <param name="source"> A sequence of 12x1 element arrays each containing the analog data to write
         /// to channels 0 to 11.</param>
@@ -158,20 +161,20 @@ namespace OpenEphys.Onix1
         /// to 11.</returns>
         public IObservable<float[]> Process(IObservable<float[]> source)
         {
-            if (DataType != BreakoutAnalogIODataType.Volts)
+            if (DataType != AnalogIODataType.Volts)
                 ThrowDataTypeException(Depth.F32);
 
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
-                var device = deviceInfo.GetDeviceContext(typeof(BreakoutAnalogIO));
-                var divisionsPerVolt = 1 / BreakoutAnalogIODeviceInfo.GetVoltsPerDivision(OutputRange);
+                var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
+                var divisionsPerVolt = 1 / AnalogIODeviceInfo.GetVoltsPerDivision(OutputRange);
                 return source.Do(data =>
                 {
                     AssertChannelCount(data.Length);
                     var samples = new ushort[data.Length];
                     for (int i = 0; i < samples.Length; i++)
                     {
-                        samples[i] = (ushort)(data[i] * divisionsPerVolt + BreakoutAnalogIO.DacMidScale);
+                        samples[i] = (ushort)(data[i] * divisionsPerVolt + AnalogIO.DacMidScale);
                     }
 
                     device.Write(samples);
@@ -181,10 +184,10 @@ namespace OpenEphys.Onix1
 
         static void AssertChannelCount(int channels)
         {
-            if (channels != BreakoutAnalogIO.ChannelCount)
+            if (channels != AnalogIO.ChannelCount)
             {
                 throw new InvalidOperationException(
-                    $"The input data must have exactly {BreakoutAnalogIO.ChannelCount} channels."
+                    $"The input data must have exactly {AnalogIO.ChannelCount} channels."
                 );
             }
         }

--- a/OpenEphys.Onix1/AnalogOutput.cs
+++ b/OpenEphys.Onix1/AnalogOutput.cs
@@ -7,7 +7,8 @@ using OpenCV.Net;
 
 namespace OpenEphys.Onix1
 {
-    [Obsolete]
+    /// <inheritdoc cref = "AnalogOutput"/>
+    [Obsolete("Use AnalogOutput instead. This operator will be removed in version 1.0.0")]
     public class BreakoutAnalogOutput : AnalogOutput { }
 
     /// <summary>

--- a/OpenEphys.Onix1/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix1/ConfigureAnalogIO.cs
@@ -4,11 +4,12 @@ using System.Linq;
 
 namespace OpenEphys.Onix1
 {
-    [Obsolete]
+    /// <inheritdoc cref = "ConfigureAnalogIO"/>
+    [Obsolete("Use ConfigureAnalogIO instead. This operator will be removed in version 1.0.0")]
     public class ConfigureBreakoutAnalogIO : ConfigureAnalogIO { }
 
     /// <summary>
-    /// Configures the analog inputs and outputs.
+    /// Configures an analog inputs and output device.
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to data IO operators, such as <see
@@ -16,7 +17,7 @@ namespace OpenEphys.Onix1
     /// <c>DeviceName</c>.
     /// </remarks>
     [TypeConverter(typeof(SortedPropertyConverter))]
-    [Description("Configures the ONIX breakout board's analog inputs and outputs.")]
+    [Description("Configures analog inputs and outputs.")]
     public class ConfigureAnalogIO : SingleDeviceFactory
     {
         /// <summary>

--- a/OpenEphys.Onix1/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix1/ConfigureAnalogIO.cs
@@ -4,23 +4,26 @@ using System.Linq;
 
 namespace OpenEphys.Onix1
 {
+    [Obsolete]
+    public class ConfigureBreakoutAnalogIO : ConfigureAnalogIO { }
+
     /// <summary>
-    /// Configures the ONIX breakout board's analog inputs and outputs.
+    /// Configures the analog inputs and outputs.
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to data IO operators, such as <see
-    /// cref="BreakoutAnalogInput"/> and <see cref="BreakoutAnalogOutput"/>, using a shared
+    /// cref="AnalogInput"/> and <see cref="AnalogOutput"/>, using a shared
     /// <c>DeviceName</c>.
     /// </remarks>
     [TypeConverter(typeof(SortedPropertyConverter))]
     [Description("Configures the ONIX breakout board's analog inputs and outputs.")]
-    public class ConfigureBreakoutAnalogIO : SingleDeviceFactory
+    public class ConfigureAnalogIO : SingleDeviceFactory
     {
         /// <summary>
-        /// Initialize a new instance of <see cref="ConfigureBreakoutAnalogIO"/> class.
+        /// Initialize a new instance of <see cref="ConfigureAnalogIO"/> class.
         /// </summary>
-        public ConfigureBreakoutAnalogIO()
-            : base(typeof(BreakoutAnalogIO))
+        public ConfigureAnalogIO()
+            : base(typeof(AnalogIO))
         {
             DeviceAddress = 6;
         }
@@ -29,7 +32,7 @@ namespace OpenEphys.Onix1
         /// Gets or sets the device enable state.
         /// </summary>
         /// <remarks>
-        /// If set to true, <see cref="BreakoutAnalogInput"/> will produce data. If set to false, <see cref="BreakoutAnalogInput"/> will not produce data.
+        /// If set to true, <see cref="AnalogInput"/> will produce data. If set to false, <see cref="AnalogInput"/> will not produce data.
         /// </remarks>
         [Category(ConfigurationCategory)]
         [Description("Specifies whether the analog IO device is enabled.")]
@@ -40,168 +43,168 @@ namespace OpenEphys.Onix1
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 0.")]
-        public BreakoutAnalogIOVoltageRange InputRange0 { get; set; }
+        public AnalogIOVoltageRange InputRange0 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 1.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 1.")]
-        public BreakoutAnalogIOVoltageRange InputRange1 { get; set; }
+        public AnalogIOVoltageRange InputRange1 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 2.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 2.")]
-        public BreakoutAnalogIOVoltageRange InputRange2 { get; set; }
+        public AnalogIOVoltageRange InputRange2 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 3.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 3.")]
-        public BreakoutAnalogIOVoltageRange InputRange3 { get; set; }
+        public AnalogIOVoltageRange InputRange3 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 4.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 4.")]
-        public BreakoutAnalogIOVoltageRange InputRange4 { get; set; }
+        public AnalogIOVoltageRange InputRange4 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 5.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 5.")]
-        public BreakoutAnalogIOVoltageRange InputRange5 { get; set; }
+        public AnalogIOVoltageRange InputRange5 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 6.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 6.")]
-        public BreakoutAnalogIOVoltageRange InputRange6 { get; set; }
+        public AnalogIOVoltageRange InputRange6 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 7.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 7.")]
-        public BreakoutAnalogIOVoltageRange InputRange7 { get; set; }
+        public AnalogIOVoltageRange InputRange7 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 8.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 8.")]
-        public BreakoutAnalogIOVoltageRange InputRange8 { get; set; }
+        public AnalogIOVoltageRange InputRange8 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 9.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 9.")]
-        public BreakoutAnalogIOVoltageRange InputRange9 { get; set; }
+        public AnalogIOVoltageRange InputRange9 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 10.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 10.")]
-        public BreakoutAnalogIOVoltageRange InputRange10 { get; set; }
+        public AnalogIOVoltageRange InputRange10 { get; set; }
 
         /// <summary>
         /// Gets or sets the input voltage range of channel 11.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 11.")]
-        public BreakoutAnalogIOVoltageRange InputRange11 { get; set; }
+        public AnalogIOVoltageRange InputRange11 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 0.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 0.")]
-        public BreakoutAnalogIODirection Direction0 { get; set; }
+        public AnalogIODirection Direction0 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 1.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 1.")]
-        public BreakoutAnalogIODirection Direction1 { get; set; }
+        public AnalogIODirection Direction1 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 2.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 2.")]
-        public BreakoutAnalogIODirection Direction2 { get; set; }
+        public AnalogIODirection Direction2 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 3.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 3.")]
-        public BreakoutAnalogIODirection Direction3 { get; set; }
+        public AnalogIODirection Direction3 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 4.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 4.")]
-        public BreakoutAnalogIODirection Direction4 { get; set; }
+        public AnalogIODirection Direction4 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 5.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 5.")]
-        public BreakoutAnalogIODirection Direction5 { get; set; }
+        public AnalogIODirection Direction5 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 6.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 6.")]
-        public BreakoutAnalogIODirection Direction6 { get; set; }
+        public AnalogIODirection Direction6 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 7.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 7.")]
-        public BreakoutAnalogIODirection Direction7 { get; set; }
+        public AnalogIODirection Direction7 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 8.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 8.")]
-        public BreakoutAnalogIODirection Direction8 { get; set; }
+        public AnalogIODirection Direction8 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 9.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 9.")]
-        public BreakoutAnalogIODirection Direction9 { get; set; }
+        public AnalogIODirection Direction9 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 10.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 10.")]
-        public BreakoutAnalogIODirection Direction10 { get; set; }
+        public AnalogIODirection Direction10 { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of channel 11.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The direction of channel 11.")]
-        public BreakoutAnalogIODirection Direction11 { get; set; }
+        public AnalogIODirection Direction11 { get; set; }
 
         /// <summary>
         /// Configures the analog input and output device in the ONIX breakout board.
@@ -224,22 +227,22 @@ namespace OpenEphys.Onix1
             return source.ConfigureDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
-                device.WriteRegister(BreakoutAnalogIO.ENABLE, Enable ? 1u : 0u);
-                device.WriteRegister(BreakoutAnalogIO.CH00INRANGE, (uint)InputRange0);
-                device.WriteRegister(BreakoutAnalogIO.CH01INRANGE, (uint)InputRange1);
-                device.WriteRegister(BreakoutAnalogIO.CH02INRANGE, (uint)InputRange2);
-                device.WriteRegister(BreakoutAnalogIO.CH03INRANGE, (uint)InputRange3);
-                device.WriteRegister(BreakoutAnalogIO.CH04INRANGE, (uint)InputRange4);
-                device.WriteRegister(BreakoutAnalogIO.CH05INRANGE, (uint)InputRange5);
-                device.WriteRegister(BreakoutAnalogIO.CH06INRANGE, (uint)InputRange6);
-                device.WriteRegister(BreakoutAnalogIO.CH07INRANGE, (uint)InputRange7);
-                device.WriteRegister(BreakoutAnalogIO.CH08INRANGE, (uint)InputRange8);
-                device.WriteRegister(BreakoutAnalogIO.CH09INRANGE, (uint)InputRange9);
-                device.WriteRegister(BreakoutAnalogIO.CH10INRANGE, (uint)InputRange10);
-                device.WriteRegister(BreakoutAnalogIO.CH11INRANGE, (uint)InputRange11);
+                device.WriteRegister(AnalogIO.ENABLE, Enable ? 1u : 0u);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange0);
+                device.WriteRegister(AnalogIO.CH01INRANGE, (uint)InputRange1);
+                device.WriteRegister(AnalogIO.CH02INRANGE, (uint)InputRange2);
+                device.WriteRegister(AnalogIO.CH03INRANGE, (uint)InputRange3);
+                device.WriteRegister(AnalogIO.CH04INRANGE, (uint)InputRange4);
+                device.WriteRegister(AnalogIO.CH05INRANGE, (uint)InputRange5);
+                device.WriteRegister(AnalogIO.CH06INRANGE, (uint)InputRange6);
+                device.WriteRegister(AnalogIO.CH07INRANGE, (uint)InputRange7);
+                device.WriteRegister(AnalogIO.CH08INRANGE, (uint)InputRange8);
+                device.WriteRegister(AnalogIO.CH09INRANGE, (uint)InputRange9);
+                device.WriteRegister(AnalogIO.CH10INRANGE, (uint)InputRange10);
+                device.WriteRegister(AnalogIO.CH11INRANGE, (uint)InputRange11);
 
                 // Build the whole value for CHDIR and write it once
-                static uint SetIO(uint io_reg, int channel, BreakoutAnalogIODirection direction) =>
+                static uint SetIO(uint io_reg, int channel, AnalogIODirection direction) =>
                     (io_reg & ~((uint)1 << channel)) | ((uint)(direction) << channel);
 
                 var io_reg = 0u;
@@ -255,9 +258,9 @@ namespace OpenEphys.Onix1
                 io_reg = SetIO(io_reg, 9, Direction9);
                 io_reg = SetIO(io_reg, 10, Direction10);
                 io_reg = SetIO(io_reg, 11, Direction11);
-                device.WriteRegister(BreakoutAnalogIO.CHDIR, io_reg);
+                device.WriteRegister(AnalogIO.CHDIR, io_reg);
 
-                var deviceInfo = new BreakoutAnalogIODeviceInfo(device, this);
+                var deviceInfo = new AnalogIODeviceInfo(device, this);
                 return DeviceManager.RegisterDevice(deviceName, deviceInfo);
             });
         }
@@ -268,8 +271,8 @@ namespace OpenEphys.Onix1
             {
                 var properties = base.GetProperties(context, value, attributes);
                 var sortedOrder = properties.Cast<PropertyDescriptor>()
-                                            .Where(p => p.PropertyType == typeof(BreakoutAnalogIOVoltageRange)
-                                                     || p.PropertyType == typeof(BreakoutAnalogIODirection))
+                                            .Where(p => p.PropertyType == typeof(AnalogIOVoltageRange)
+                                                     || p.PropertyType == typeof(AnalogIODirection))
                                             .OrderBy(p => p.PropertyType.MetadataToken)
                                             .Select(p => p.Name)
                                             .Prepend(nameof(Enable))
@@ -279,7 +282,7 @@ namespace OpenEphys.Onix1
         }
     }
 
-    static class BreakoutAnalogIO
+    static class AnalogIO
     {
         public const int ID = 22;
 
@@ -307,15 +310,15 @@ namespace OpenEphys.Onix1
         internal class NameConverter : DeviceNameConverter
         {
             public NameConverter()
-                : base(typeof(BreakoutAnalogIO))
+                : base(typeof(AnalogIO))
             {
             }
         }
     }
 
-    class BreakoutAnalogIODeviceInfo : DeviceInfo
+    class AnalogIODeviceInfo : DeviceInfo
     {
-        public BreakoutAnalogIODeviceInfo(DeviceContext device, ConfigureBreakoutAnalogIO deviceFactory)
+        public AnalogIODeviceInfo(DeviceContext device, ConfigureAnalogIO deviceFactory)
             : base(device, deviceFactory.DeviceType)
         {
             VoltsPerDivision = new[]
@@ -335,13 +338,13 @@ namespace OpenEphys.Onix1
             };
         }
 
-        public static float GetVoltsPerDivision(BreakoutAnalogIOVoltageRange voltageRange)
+        public static float GetVoltsPerDivision(AnalogIOVoltageRange voltageRange)
         {
             return voltageRange switch
             {
-                BreakoutAnalogIOVoltageRange.TenVolts => 20.0f / BreakoutAnalogIO.NumberOfDivisions,
-                BreakoutAnalogIOVoltageRange.TwoPointFiveVolts => 5.0f / BreakoutAnalogIO.NumberOfDivisions,
-                BreakoutAnalogIOVoltageRange.FiveVolts => 10.0f / BreakoutAnalogIO.NumberOfDivisions,
+                AnalogIOVoltageRange.TenVolts => 20.0f / AnalogIO.NumberOfDivisions,
+                AnalogIOVoltageRange.TwoPointFiveVolts => 5.0f / AnalogIO.NumberOfDivisions,
+                AnalogIOVoltageRange.FiveVolts => 10.0f / AnalogIO.NumberOfDivisions,
                 _ => throw new ArgumentOutOfRangeException(nameof(voltageRange)),
             };
         }
@@ -352,7 +355,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Specifies the analog input ADC voltage range.
     /// </summary>
-    public enum BreakoutAnalogIOVoltageRange
+    public enum AnalogIOVoltageRange
     {
         /// <summary>
         /// ±10.0 volts.
@@ -374,7 +377,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Specifies analog channel direction.
     /// </summary>
-    public enum BreakoutAnalogIODirection
+    public enum AnalogIODirection
     {
         /// <summary>
         /// Input to breakout board.
@@ -389,7 +392,7 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// Specifies the analog sample representation.
     /// </summary>
-    public enum BreakoutAnalogIODataType
+    public enum AnalogIODataType
     {
         /// <summary>
         /// Twos-complement encoded signed 16-bit integer

--- a/OpenEphys.Onix1/ConfigureBreakoutBoard.cs
+++ b/OpenEphys.Onix1/ConfigureBreakoutBoard.cs
@@ -36,7 +36,7 @@ namespace OpenEphys.Onix1
         [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the analog IO device in the ONIX breakout board.")]
         [Category(DevicesCategory)]
-        public ConfigureBreakoutAnalogIO AnalogIO { get; set; } = new();
+        public ConfigureAnalogIO AnalogIO { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the breakout board's digital IO configuration.
@@ -44,7 +44,7 @@ namespace OpenEphys.Onix1
         [TypeConverter(typeof(SingleDeviceFactoryConverter))]
         [Description("Specifies the configuration for the digital IO device in the ONIX breakout board.")]
         [Category(DevicesCategory)]
-        public ConfigureBreakoutDigitalIO DigitalIO { get; set; } = new();
+        public ConfigureDigitalIO DigitalIO { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the breakout board's output clock configuration.

--- a/OpenEphys.Onix1/ConfigureDigitalIO.cs
+++ b/OpenEphys.Onix1/ConfigureDigitalIO.cs
@@ -3,7 +3,8 @@ using System.ComponentModel;
 
 namespace OpenEphys.Onix1
 {
-    [Obsolete]
+    /// <inheritdoc cref = "ConfigureDigitalIO"/>
+    [Obsolete("Use ConfigureDigitalIO instead. This operator will be removed in version 1.0.0v")]
     public class ConfigureBreakoutDigitalIO : ConfigureDigitalIO { }
 
     /// <summary>

--- a/OpenEphys.Onix1/ConfigureDigitalIO.cs
+++ b/OpenEphys.Onix1/ConfigureDigitalIO.cs
@@ -3,22 +3,25 @@ using System.ComponentModel;
 
 namespace OpenEphys.Onix1
 {
+    [Obsolete]
+    public class ConfigureBreakoutDigitalIO : ConfigureDigitalIO { }
+
     /// <summary>
     /// Configures the ONIX breakout board's digital inputs and outputs.
     /// </summary>
     /// <remarks>
     /// This configuration operator can be linked to data IO operators, such as <see
-    /// cref="BreakoutDigitalInput"/> and <see cref="BreakoutDigitalOutput"/>, using a shared
+    /// cref="DigitalInput"/> and <see cref="DigitalOutput"/>, using a shared
     /// <c>DeviceName</c>.
     /// </remarks>
     [Description("Configures the ONIX breakout board's digital inputs and outputs.")]
-    public class ConfigureBreakoutDigitalIO : SingleDeviceFactory
+    public class ConfigureDigitalIO : SingleDeviceFactory
     {
         /// <summary>
-        /// Initialize a new instance of the <see cref="ConfigureBreakoutDigitalIO"/> class.
+        /// Initialize a new instance of the <see cref="ConfigureDigitalIO"/> class.
         /// </summary>
-        public ConfigureBreakoutDigitalIO()
-            : base(typeof(BreakoutDigitalIO))
+        public ConfigureDigitalIO()
+            : base(typeof(DigitalIO))
         {
             DeviceAddress = 7;
         }
@@ -27,8 +30,8 @@ namespace OpenEphys.Onix1
         /// Gets or sets the device enable state.
         /// </summary>
         /// <remarks>
-        /// If set to true, <see cref="BreakoutDigitalInput"/> will produce data. If set to false, <see
-        /// cref="BreakoutDigitalInput"/> will not produce data.
+        /// If set to true, <see cref="DigitalInput"/> will produce data. If set to false, <see
+        /// cref="DigitalInput"/> will not produce data.
         /// </remarks>
         [Category(ConfigurationCategory)]
         [Description("Specifies whether the digital IO device is enabled.")]
@@ -54,13 +57,13 @@ namespace OpenEphys.Onix1
             return source.ConfigureDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
-                device.WriteRegister(BreakoutDigitalIO.ENABLE, Enable ? 1u : 0);
+                device.WriteRegister(DigitalIO.ENABLE, Enable ? 1u : 0);
                 return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });
         }
     }
 
-    static class BreakoutDigitalIO
+    static class DigitalIO
     {
         public const int ID = 18;
 
@@ -70,7 +73,7 @@ namespace OpenEphys.Onix1
         internal class NameConverter : DeviceNameConverter
         {
             public NameConverter()
-                : base(typeof(BreakoutDigitalIO))
+                : base(typeof(DigitalIO))
             {
             }
         }
@@ -80,7 +83,7 @@ namespace OpenEphys.Onix1
     /// Specifies the state of the ONIX breakout board's digital input pins.
     /// </summary>
     [Flags]
-    public enum BreakoutDigitalPortState : ushort
+    public enum DigitalPortState : ushort
     {
         /// <summary>
         /// Specifies that pin 0 is high.

--- a/OpenEphys.Onix1/DigitalInput.cs
+++ b/OpenEphys.Onix1/DigitalInput.cs
@@ -6,7 +6,8 @@ using Bonsai;
 
 namespace OpenEphys.Onix1
 {
-    [Obsolete]
+    /// <inheritdoc cref = "DigitalInput"/>
+    [Obsolete("Use DigitalInput instead. This operator will be removed in version 1.0.0")]
     public class BreakoutDigitalInput : DigitalInput { }
 
     /// <summary>

--- a/OpenEphys.Onix1/DigitalInput.cs
+++ b/OpenEphys.Onix1/DigitalInput.cs
@@ -6,18 +6,21 @@ using Bonsai;
 
 namespace OpenEphys.Onix1
 {
+    [Obsolete]
+    public class BreakoutDigitalInput : DigitalInput { }
+
     /// <summary>
     /// Produces a sequence of digital input data from an ONIX breakout board.
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureBreakoutDigitalIO"/>, using a shared <c>DeviceName</c>.
+    /// cref="ConfigureDigitalIO"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Produces a sequence of digital input frames from an ONIX breakout board.")]
-    public class BreakoutDigitalInput : Source<BreakoutDigitalInputDataFrame>
+    public class DigitalInput : Source<DigitalInputDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
-        [TypeConverter(typeof(BreakoutDigitalIO.NameConverter))]
+        [TypeConverter(typeof(DigitalIO.NameConverter))]
         [Description(SingleDeviceFactory.DeviceNameDescription)]
         [Category(DeviceFactory.ConfigurationCategory)]
         public string DeviceName { get; set; }
@@ -27,18 +30,18 @@ namespace OpenEphys.Onix1
         /// breakout board's digital input state.
         /// </summary>
         /// <remarks>
-        /// Digital inputs are sampled at 4 MHz but a <see cref="BreakoutDigitalInputDataFrame"/> is produced
+        /// Digital inputs are sampled at 4 MHz but a <see cref="DigitalInputDataFrame"/> is produced
         /// only when a button, switch, or digital input pin is toggled.
         /// </remarks>
-        /// <returns>A sequence of <see cref="BreakoutDigitalInputDataFrame"/> objects.</returns>
-        public unsafe override IObservable<BreakoutDigitalInputDataFrame> Generate()
+        /// <returns>A sequence of <see cref="DigitalInputDataFrame"/> objects.</returns>
+        public unsafe override IObservable<DigitalInputDataFrame> Generate()
         {
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
-                var device = deviceInfo.GetDeviceContext(typeof(BreakoutDigitalIO));
+                var device = deviceInfo.GetDeviceContext(typeof(DigitalIO));
                 return deviceInfo.Context
                     .GetDeviceFrames(device.Address)
-                    .Select(frame => new BreakoutDigitalInputDataFrame(frame));
+                    .Select(frame => new DigitalInputDataFrame(frame));
             });
         }
     }

--- a/OpenEphys.Onix1/DigitalInputDataFrame.cs
+++ b/OpenEphys.Onix1/DigitalInputDataFrame.cs
@@ -5,16 +5,16 @@ namespace OpenEphys.Onix1
     /// <summary>
     /// A digital event produced by the ONIX breakout board.
     /// </summary>
-    public class BreakoutDigitalInputDataFrame : DataFrame
+    public class DigitalInputDataFrame : DataFrame
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="BreakoutDigitalInputDataFrame"/> class.
+        /// Initializes a new instance of the <see cref="DigitalInputDataFrame"/> class.
         /// </summary>
         /// <param name="frame">A frame produced by an ONIX breakout board's digital IO device.</param>
-        public unsafe BreakoutDigitalInputDataFrame(oni.Frame frame)
+        public unsafe DigitalInputDataFrame(oni.Frame frame)
             : base(frame.Clock)
         {
-            var payload = (BreakoutDigitalInputPayload*)frame.Data.ToPointer();
+            var payload = (DigitalInputPayload*)frame.Data.ToPointer();
             HubClock = payload->HubClock;
             DigitalInputs = payload->DigitalInputs;
             Buttons = payload->Buttons;
@@ -23,7 +23,7 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Gets the state of the breakout board's 8-bit digital input port.
         /// </summary>
-        public BreakoutDigitalPortState DigitalInputs { get; }
+        public DigitalPortState DigitalInputs { get; }
 
         /// <summary>
         /// Gets the state of the breakout board's buttons and switches.
@@ -32,10 +32,10 @@ namespace OpenEphys.Onix1
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    struct BreakoutDigitalInputPayload
+    struct DigitalInputPayload
     {
         public ulong HubClock;
-        public BreakoutDigitalPortState DigitalInputs;
+        public DigitalPortState DigitalInputs;
         public BreakoutButtonState Buttons;
     }
 }

--- a/OpenEphys.Onix1/DigitalOutput.cs
+++ b/OpenEphys.Onix1/DigitalOutput.cs
@@ -6,18 +6,21 @@ using Bonsai;
 
 namespace OpenEphys.Onix1
 {
+    [Obsolete]
+    public class BreakoutDigitalOutput : DigitalOutput { }
+
     /// <summary>
     /// Sends digital output data to an ONIX breakout board.
     /// </summary>
     /// <remarks>
     /// This data IO operator must be linked to an appropriate configuration, such as a <see
-    /// cref="ConfigureBreakoutDigitalIO"/>, using a shared <c>DeviceName</c>.
+    /// cref="ConfigureDigitalIO"/>, using a shared <c>DeviceName</c>.
     /// </remarks>
     [Description("Sends digital output data to an ONIX breakout board.")]
-    public class BreakoutDigitalOutput : Sink<BreakoutDigitalPortState>
+    public class DigitalOutput : Sink<DigitalPortState>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
-        [TypeConverter(typeof(BreakoutDigitalIO.NameConverter))]
+        [TypeConverter(typeof(DigitalIO.NameConverter))]
         [Description(SingleDeviceFactory.DeviceNameDescription)]
         [Category(DeviceFactory.ConfigurationCategory)]
         public string DeviceName { get; set; }
@@ -25,13 +28,13 @@ namespace OpenEphys.Onix1
         /// <summary>
         /// Updates the digital output port state.
         /// </summary>
-        /// <param name="source"> A sequence of <see cref="BreakoutDigitalPortState"/> values indicating the state of the breakout board's 8 digital output pins</param>
+        /// <param name="source"> A sequence of <see cref="DigitalPortState"/> values indicating the state of the breakout board's 8 digital output pins</param>
         /// <returns> A sequence that is identical to <paramref name="source"/>.</returns>
-        public override IObservable<BreakoutDigitalPortState> Process(IObservable<BreakoutDigitalPortState> source)
+        public override IObservable<DigitalPortState> Process(IObservable<DigitalPortState> source)
         {
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
-                var device = deviceInfo.GetDeviceContext(typeof(BreakoutDigitalIO));
+                var device = deviceInfo.GetDeviceContext(typeof(DigitalIO));
                 return source.Do(value => device.Write((uint)value));
             });
         }

--- a/OpenEphys.Onix1/DigitalOutput.cs
+++ b/OpenEphys.Onix1/DigitalOutput.cs
@@ -6,7 +6,8 @@ using Bonsai;
 
 namespace OpenEphys.Onix1
 {
-    [Obsolete]
+    /// <inheritdoc cref = "DigitalOutput"/>
+    [Obsolete("Use DigitalOutput instead. This operator will be removed in version 1.0.0")]
     public class BreakoutDigitalOutput : DigitalOutput { }
 
     /// <summary>

--- a/OpenEphys.Onix1/StartAcquisition.cs
+++ b/OpenEphys.Onix1/StartAcquisition.cs
@@ -34,7 +34,7 @@ namespace OpenEphys.Onix1
     /// </item>
     /// </list>
     /// These pre-sorted frame sequences can be interpreted by downstream Data I/O operators (e.g. <see
-    /// cref="BreakoutAnalogInput"/> or <see cref="Bno055Data"/>) that convert <see
+    /// cref="AnalogInput"/> or <see cref="Bno055Data"/>) that convert <see
     /// href="https://open-ephys.github.io/ONI/hw-spec/controller.html#data-frames">ONI Data Frames</see> into
     /// data types that are are more amenable to processing within Bonsai workflows.
     /// </remarks>


### PR DESCRIPTION
- Preserve backwards compatibility with old workflows.
- ~This commit requires a major revision increment~ Because we are in the 0 major revision, this change is permitted, even though its API breaking
- Fixes #297 
- Fixes #300 
- After this is merged, I will create 1.0.0 issue requesting the removal of obsolete types