### PR TITLE
Fix badly formed XML comment

### DIFF
--- a/OpenEphys.Onix1/ConfigureBreakoutBoard.cs
+++ b/OpenEphys.Onix1/ConfigureBreakoutBoard.cs
@@ -54,6 +54,7 @@ namespace OpenEphys.Onix1
         [Category(DevicesCategory)]
         public ConfigureOutputClock ClockOutput { get; set; } = new();
 
+        /// <summary>
         /// Gets or sets the the Harp synchronization input configuration.
         /// </summary>
         [TypeConverter(typeof(SingleDeviceFactoryConverter))]


### PR DESCRIPTION
- HarpInput summary in ConfigureBreakoutBoard was missing a `<summary>` tag.

Requested review from either jonnew or bparks13, doesn't really matter - whoever gets to it first.